### PR TITLE
TreeModel refactor

### DIFF
--- a/include/fastdds_monitor/backend/backend_utils.h
+++ b/include/fastdds_monitor/backend/backend_utils.h
@@ -88,6 +88,10 @@ backend::DataKind string_to_data_kind(
 backend::StatisticKind string_to_statistic_kind(
         const QString& statistic_kind);
 
+
+//! recursive function to convert array json subelements to dictionaries indexed by numbers
+backend::EntityInfo refactor_json(backend::EntityInfo json_data);
+
 } //namespace backend
 
 #endif // _EPROSIMA_FASTDDS_MONITOR_BACKEND_BACKENDUTILS_H

--- a/include/fastdds_monitor/backend/backend_utils.h
+++ b/include/fastdds_monitor/backend/backend_utils.h
@@ -90,7 +90,8 @@ backend::StatisticKind string_to_statistic_kind(
 
 
 //! recursive function to convert array json subelements to dictionaries indexed by numbers
-backend::EntityInfo refactor_json(backend::EntityInfo json_data);
+backend::EntityInfo refactor_json(
+        backend::EntityInfo json_data);
 
 } //namespace backend
 

--- a/include/fastdds_monitor/model/tree/TreeModel.h
+++ b/include/fastdds_monitor/model/tree/TreeModel.h
@@ -106,7 +106,7 @@ public:
 
     //! Clear the model and create a new tree with new data
     void update(
-            const json& data);
+            json data);
 
     //! Return the role names of the values in nodes to acces them via \c data
     QHash<int, QByteArray> roleNames() const Q_DECL_OVERRIDE;
@@ -128,12 +128,20 @@ protected:
      * It iterates over a json object, each key is created as a new subnode and the values
      * are used to fill this subnode with this same function.
      *
+     * Go through the whole json and its subelements and change every array of elements by a dictionary
+     * indexed by numbers starting in 0.
+     * For the first element, adds an empty row at the end to prevent the TreeView(*) error.
+     *
+     * (*) TreeView does not collapse correctly a subtree in case its last element is itself a subtree and
+     * it is not collapsed.
      * @param json_data data in json format to fill the item
      * @param parent item to fill
+     * @param _first wether is the parent element of the json (false only used in internal recursion)
      */
     static void setup_model_data(
             const json& json_data,
-            TreeItem* parent);
+            TreeItem* parent,
+            bool _first = true);
 
 private:
 

--- a/qml/DynamicStatisticsChartView.qml
+++ b/qml/DynamicStatisticsChartView.qml
@@ -286,7 +286,7 @@ ChartView {
 
     function customRemoveSeries(seriesIndex){
         mapper.splice(seriesIndex, 1)
-        if (mapper.empty()){
+        if (mapper.length == 0){
             running = false
         }
     }

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -307,7 +307,7 @@ bool SyncBackendConnection::update_item_info_(
     try
     {
         // Query for this item info and updte it
-        item->info(StatisticsBackend::get_info(item->get_entity_id()));
+        item->info(get_info(item->get_entity_id()));
         item->triggerItemUpdate();
         return true;
     }
@@ -462,7 +462,8 @@ EntityInfo SyncBackendConnection::get_info(
 {
     try
     {
-        return StatisticsBackend::get_info(id);
+        // Refactor json info so there are no vectors
+        return backend::refactor_json(StatisticsBackend::get_info(id));
     }
     catch (const Exception& e)
     {
@@ -932,7 +933,7 @@ ListModel* SyncBackendConnection::get_model_(
 
     try
     {
-        auto parents = StatisticsBackend::get_entities(parent_kind, id);
+        std::vector<backend::EntityId> parents = get_entities(parent_kind, id);
 
         // It must be just one host
         if (parents.size() != 1)

--- a/src/backend/backend_utils.cpp
+++ b/src/backend/backend_utils.cpp
@@ -306,4 +306,34 @@ bool get_info_alive(
     }
 }
 
+backend::EntityInfo refactor_json(
+        backend::EntityInfo json_data)
+{
+    if (json_data.is_array())
+    {
+        // In this case it is already a correct json
+        // Iterate over elements and refactor them
+        int counter = 0;
+        backend::EntityInfo new_json;
+        for (auto& element : json_data)
+        {
+            new_json[std::to_string(counter++)] = refactor_json(element);
+        }
+
+        return new_json;
+    }
+    else if (json_data.is_object())
+    {
+        // In this case it is already a correct json
+        // Iterate over elements and refactor them
+        for (auto& element : json_data.items())
+        {
+            json_data[element.key()] = refactor_json(element.value());
+        }
+    }
+
+    // Otherwise is primitive or null and it is already correct
+    return json_data;
+}
+
 } // namespace backend


### PR DESCRIPTION
- Refactor `get_info` so it does not contain vectors.
- Add an empty line at the end of every TreeModel so it collapse correctly
- fix javascript length parameter
- Encapsulate backend calls in simple functions

Signed-off-by: jparisu <javierparis@eprosima.com>