### PR TITLE
Remove FastDDSGen and IDL-parser from .repos

### DIFF
--- a/fastdds_monitor.repos
+++ b/fastdds_monitor.repos
@@ -15,14 +15,6 @@ repositories:
         type: git
         url: https://github.com/eProsima/Fast-DDS-statistics-backend.git
         version: main
-    fastrtpsgen:
-        type: git
-        url: https://github.com/eProsima/Fast-DDS-Gen.git
-        version: master
-    fastrtpsgen/thirdparty/idl-parser:
-        type: git
-        url: https://github.com/eProsima/IDL-Parser.git
-        version: master
     fastdds_monitor:
         type: git
         url: https://github.com/eProsima/Fast-DDS-monitor.git


### PR DESCRIPTION
Signed-off-by: jparisu <javierparis@eprosima.com>