### PR TITLE
Fix maximum domain id cap

### DIFF
--- a/qml/InitMonitorDialog.qml
+++ b/qml/InitMonitorDialog.qml
@@ -44,7 +44,7 @@ Dialog {
             editable: true
             value: 0
             from: 0
-            to: 999
+            to: 232
             Layout.alignment: Qt.AlignTop
             Keys.onReturnPressed: dialogInitMonitor.accept()
         }


### PR DESCRIPTION
Signed-off-by: JesusPoderoso <jesuspoderoso@eprosima.com>

If manually enter a number higher than 232, it gets set as 232.
If click the spinbox until 232 is reached, it does not increase any more.