### PR TITLE
Rename enum DOMAIN to avoid System V macro conflict

### DIFF
--- a/include/fastdds_monitor/model/logical/DomainModelItem.h
+++ b/include/fastdds_monitor/model/logical/DomainModelItem.h
@@ -45,7 +45,7 @@ public:
     //! Overwriter entity kind
     virtual backend::EntityKind backend_kind() const override
     {
-        return backend::EntityKind::DOMAIN;
+        return backend::EntityKind::DOMAIN_ENTITY;
     }
 
 };

--- a/mock/complex_mock/entities/headers/Domain.hpp
+++ b/mock/complex_mock/entities/headers/Domain.hpp
@@ -54,7 +54,7 @@ public:
     //! Overwrite of \c kind method from Entity
     EntityKind kind() const override
     {
-        return EntityKind::DOMAIN;
+        return EntityKind::DOMAIN_ENTITY;
     }
 
 private:

--- a/mock/complex_mock/entities/source/Domain.cpp
+++ b/mock/complex_mock/entities/source/Domain.cpp
@@ -42,7 +42,7 @@ std::vector<EntityId> Domain::get_entities(
         case EntityKind::PARTICIPANT:
             return get_ids(participants_);
 
-        case EntityKind::DOMAIN:
+        case EntityKind::DOMAIN_ENTITY:
             return ids;
 
         case EntityKind::TOPIC:

--- a/mock/complex_mock/entities/source/Endpoint.cpp
+++ b/mock/complex_mock/entities/source/Endpoint.cpp
@@ -41,7 +41,7 @@ std::vector<EntityId> Endpoint::get_entities(
             ids.push_back(participant_->id());
             return ids;
 
-        case EntityKind::DOMAIN:
+        case EntityKind::DOMAIN_ENTITY:
 
         case EntityKind::DATAWRITER:
         case EntityKind::DATAREADER:

--- a/mock/complex_mock/entities/source/Host.cpp
+++ b/mock/complex_mock/entities/source/Host.cpp
@@ -39,7 +39,7 @@ std::vector<EntityId> Host::get_entities(
             return get_ids(users_);
 
         case EntityKind::PROCESS:
-        case EntityKind::DOMAIN:
+        case EntityKind::DOMAIN_ENTITY:
         case EntityKind::TOPIC:
         case EntityKind::PARTICIPANT:
         case EntityKind::DATAWRITER:

--- a/mock/complex_mock/entities/source/Locator.cpp
+++ b/mock/complex_mock/entities/source/Locator.cpp
@@ -37,7 +37,7 @@ std::vector<EntityId> Locator::get_entities(
         case EntityKind::USER:
         case EntityKind::PROCESS:
         case EntityKind::PARTICIPANT:
-        case EntityKind::DOMAIN:
+        case EntityKind::DOMAIN_ENTITY:
         case EntityKind::TOPIC:
             return get_entities_related(endpoints_, entity_type);
 

--- a/mock/complex_mock/entities/source/Participant.cpp
+++ b/mock/complex_mock/entities/source/Participant.cpp
@@ -46,7 +46,7 @@ std::vector<EntityId> Participant::get_entities(
         case EntityKind::PARTICIPANT:
             return ids;
 
-        case EntityKind::DOMAIN:
+        case EntityKind::DOMAIN_ENTITY:
             ids.push_back(domain_->id());
             return ids;
 

--- a/mock/complex_mock/entities/source/Process.cpp
+++ b/mock/complex_mock/entities/source/Process.cpp
@@ -45,7 +45,7 @@ std::vector<EntityId> Process::get_entities(
         case EntityKind::PARTICIPANT:
             return get_ids(participants_);
 
-        case EntityKind::DOMAIN:
+        case EntityKind::DOMAIN_ENTITY:
         case EntityKind::TOPIC:
         case EntityKind::DATAWRITER:
         case EntityKind::DATAREADER:

--- a/mock/complex_mock/entities/source/Topic.cpp
+++ b/mock/complex_mock/entities/source/Topic.cpp
@@ -40,7 +40,7 @@ std::vector<EntityId> Topic::get_entities(
         case EntityKind::PARTICIPANT:
             return get_entities_related(endpoints_, entity_type);
 
-        case EntityKind::DOMAIN:
+        case EntityKind::DOMAIN_ENTITY:
             ids.push_back(domain_->id());
             return ids;
 

--- a/mock/complex_mock/entities/source/User.cpp
+++ b/mock/complex_mock/entities/source/User.cpp
@@ -42,7 +42,7 @@ std::vector<EntityId> User::get_entities(
         case EntityKind::PROCESS:
             return get_ids(processes_);
 
-        case EntityKind::DOMAIN:
+        case EntityKind::DOMAIN_ENTITY:
         case EntityKind::TOPIC:
         case EntityKind::PARTICIPANT:
         case EntityKind::DATAWRITER:

--- a/mock/static_mock/StatisticsBackend.cpp
+++ b/mock/static_mock/StatisticsBackend.cpp
@@ -134,7 +134,7 @@ std::vector<EntityId> StatisticsBackend::get_entities(
             result.push_back(3);
             break;
 
-        case EntityKind::DOMAIN:
+        case EntityKind::DOMAIN_ENTITY:
             result.push_back(4);
             break;
 
@@ -181,7 +181,7 @@ EntityKind StatisticsBackend::get_type(
             return EntityKind::PROCESS;
 
         case 4:
-            return EntityKind::DOMAIN;
+            return EntityKind::DOMAIN_ENTITY;
 
         case 5:
             return EntityKind::TOPIC;

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -61,7 +61,7 @@ void Controller::process_click(
 void Controller::domain_click(
         QString id)
 {
-    engine_->entity_clicked(backend::models_id_to_backend_id(id), backend::EntityKind::DOMAIN);
+    engine_->entity_clicked(backend::models_id_to_backend_id(id), backend::EntityKind::DOMAIN_ENTITY);
 }
 
 void Controller::topic_click(

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -278,7 +278,7 @@ void Engine::shared_init_monitor_(
         // This, entity_clicked must be called but do not update dds model (but reset it)
         update_entity(domain_id, &Engine::update_domain, true, false);
 
-        entity_clicked(domain_id, backend::EntityKind::DOMAIN, false);
+        entity_clicked(domain_id, backend::EntityKind::DOMAIN_ENTITY, false);
 
         emit controller_->monitorInitialized();
     }
@@ -917,7 +917,7 @@ bool Engine::update_entity_generic(
             return update_entity(
                 entity_id, &Engine::update_process, !is_update, is_last_clicked);
 
-        case backend::EntityKind::DOMAIN:
+        case backend::EntityKind::DOMAIN_ENTITY:
             return update_entity(
                 entity_id, &Engine::update_domain, !is_update, is_last_clicked);
 
@@ -1104,7 +1104,7 @@ void Engine::set_alias(
             update_entity(entity_id, &Engine::update_process, false);
             break;
 
-        case backend::EntityKind::DOMAIN:
+        case backend::EntityKind::DOMAIN_ENTITY:
             update_entity(entity_id, &Engine::update_domain, false);
             break;
 
@@ -1331,7 +1331,7 @@ EntitiesClicked::click(
         case backend::EntityKind::HOST:
         case backend::EntityKind::USER:
         case backend::EntityKind::PROCESS:
-        case backend::EntityKind::DOMAIN:
+        case backend::EntityKind::DOMAIN_ENTITY:
         case backend::EntityKind::TOPIC:
             std::get<2>(result) = unclick_dds();
             std::get<1>(result) = physical_logical.set(clicked_entity, clicked_kind);

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -274,7 +274,7 @@ bool SyncBackendConnection::update_logical_model(
 
     return update_model_(
         logical_model,
-        EntityKind::DOMAIN,
+        EntityKind::DOMAIN_ENTITY,
         ID_ALL,
         &SyncBackendConnection::update_domain_item,
         &SyncBackendConnection::create_domain_data_,
@@ -948,7 +948,7 @@ bool SyncBackendConnection::update_topic(
         bool last_clicked)
 {
     // Get Domain model where this Topic belongs
-    ListModel* domain_model = get_model_(logical_model, id, EntityKind::DOMAIN);
+    ListModel* domain_model = get_model_(logical_model, id, EntityKind::DOMAIN_ENTITY);
 
     if (domain_model == nullptr)
     {

--- a/src/backend/backend_utils.cpp
+++ b/src/backend/backend_utils.cpp
@@ -82,7 +82,7 @@ QString entity_kind_to_QString(
             return "User";
         case EntityKind::PROCESS:
             return "Process";
-        case EntityKind::DOMAIN:
+        case EntityKind::DOMAIN_ENTITY:
             return "Domain";
         case EntityKind::TOPIC:
             return "Topic";
@@ -176,7 +176,7 @@ EntityKind string_to_entity_kind(
         {"Host", EntityKind::HOST},
         {"User", EntityKind::USER},
         {"Process", EntityKind::PROCESS},
-        {"Domain", EntityKind::DOMAIN},
+        {"Domain", EntityKind::DOMAIN_ENTITY},
         {"Topic", EntityKind::TOPIC},
         {"DomainParticipant", EntityKind::PARTICIPANT},
         {"DataWriter", EntityKind::DATAWRITER},

--- a/test/unittest/utils/backend_utilsTest.cpp
+++ b/test/unittest/utils/backend_utilsTest.cpp
@@ -85,7 +85,7 @@ TEST(utilsBackendTest, string_to_entity_kind)
         {"Host", EntityKind::HOST},
         {"User", EntityKind::USER},
         {"Process", EntityKind::PROCESS},
-        {"Domain", EntityKind::DOMAIN},
+        {"Domain", EntityKind::DOMAIN_ENTITY},
         {"Topic", EntityKind::TOPIC},
         {"DomainParticipant", EntityKind::PARTICIPANT},
         {"DataWriter", EntityKind::DATAWRITER},


### PR DESCRIPTION
Update `EntityKind::DOMAIN` to `EntityKind::DOMAIN_ENTITY` to avoid conflict with System V macro of the same name.

### Dependencies

- https://github.com/eProsima/Fast-DDS-statistics-backend/pull/195

### Motivation

With this PR and

- https://github.com/eProsima/dev-utils/pull/81

Fast DDS monitor will build and run on macOS.

![dds-monitor-services](https://github.com/eProsima/Fast-DDS-monitor/assets/24916364/2c0c97d3-c7e2-46ef-9444-5d4180646145)

