### PR TITLE
[19865] Include Fast DDS Monitor app ID while init monitor, and include new arguments in mocks 

### DIFF
--- a/mock/complex_mock/StatisticsBackend.cpp
+++ b/mock/complex_mock/StatisticsBackend.cpp
@@ -70,9 +70,11 @@ EntityId StatisticsBackend::init_monitor(
         DomainId domain,
         DomainListener* domain_listener,
         CallbackMask callback_mask,
-        DataKindMask data_mask)
+        DataKindMask data_mask,
+        std::string app_id,
+        std::string app_metadata)
 {
-    return init_monitor(std::to_string(domain), domain_listener, callback_mask, data_mask);
+    return init_monitor(std::to_string(domain), domain_listener, callback_mask, data_mask, app_id, app_metadata);
 }
 
 // Add a new Domain in the Database
@@ -81,12 +83,16 @@ EntityId StatisticsBackend::init_monitor(
         std::string discovery_server_locators,
         DomainListener* domain_listener,
         CallbackMask callback_mask,
-        DataKindMask data_mask)
+        DataKindMask data_mask,
+        std::string app_id,
+        std::string app_metadata)
 {
     static_cast<void>(discovery_server_locators);
     static_cast<void>(domain_listener);
     static_cast<void>(callback_mask);
     static_cast<void>(data_mask);
+    static_cast<void>(app_id);
+    static_cast<void>(app_metadata);
 
     if (Database::get_instance()->count_domains() == 0)
     {

--- a/mock/static_mock/StatisticsBackend.cpp
+++ b/mock/static_mock/StatisticsBackend.cpp
@@ -88,12 +88,16 @@ EntityId StatisticsBackend::init_monitor(
         DomainId domain,
         DomainListener* domain_listener,
         CallbackMask callback_mask,
-        DataKindMask data_mask)
+        DataKindMask data_mask,
+        std::string app_id,
+        std::string app_metadata)
 {
     static_cast<void>(domain);
     static_cast<void>(domain_listener);
     static_cast<void>(callback_mask);
     static_cast<void>(data_mask);
+    static_cast<void>(app_id);
+    static_cast<void>(app_metadata);
     return EntityId(++ID);
 }
 
@@ -102,12 +106,16 @@ EntityId StatisticsBackend::init_monitor(
         std::string discovery_server_locators,
         DomainListener* domain_listener,
         CallbackMask callback_mask,
-        DataKindMask data_mask)
+        DataKindMask data_mask,
+        std::string app_id,
+        std::string app_metadata)
 {
     static_cast<void>(discovery_server_locators);
     static_cast<void>(domain_listener);
     static_cast<void>(callback_mask);
     static_cast<void>(data_mask);
+    static_cast<void>(app_id);
+    static_cast<void>(app_metadata);
     return EntityId(++ID);
 }
 

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -442,7 +442,7 @@ EntityId SyncBackendConnection::init_monitor(
 {
     try
     {
-        return StatisticsBackend::init_monitor(domain);
+        return StatisticsBackend::init_monitor(domain, nullptr, CallbackMask::all(), DataKindMask::none(), FASTDDS_MONITOR_APP);
     }
     catch (const Error& e)
     {
@@ -464,7 +464,8 @@ EntityId SyncBackendConnection::init_monitor(
     {
         return StatisticsBackend::init_monitor(
             discovery_server_guid_prefix,
-            discovery_server_locators);
+            discovery_server_locators,
+            nullptr, CallbackMask::all(), DataKindMask::none(), FASTDDS_MONITOR_APP);
     }
     catch (const Error& e)
     {

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -442,7 +442,8 @@ EntityId SyncBackendConnection::init_monitor(
 {
     try
     {
-        return StatisticsBackend::init_monitor(domain, nullptr, CallbackMask::all(), DataKindMask::none(), FASTDDS_MONITOR_APP);
+        return StatisticsBackend::init_monitor(domain, nullptr, CallbackMask::all(),
+                       DataKindMask::none(), FASTDDS_MONITOR_APP);
     }
     catch (const Error& e)
     {
@@ -890,7 +891,6 @@ bool SyncBackendConnection::get_status_data(
     }
     return false;
 }
-
 
 bool SyncBackendConnection::build_source_target_entities_vectors(
         DataKind data_kind,


### PR DESCRIPTION
This PR should be merged after:
- #207 