### PR TITLE
[21446] Fast DDS Monitor refactor: Fast DDS v3 compatibility

### DIFF
--- a/.github/workflows/clang_colcon.meta
+++ b/.github/workflows/clang_colcon.meta
@@ -1,7 +1,7 @@
 {
     "names":
     {
-        "fastrtps":
+        "fastdds":
         {
             "cmake-args":
             [

--- a/.github/workflows/configurations/requirements.txt
+++ b/.github/workflows/configurations/requirements.txt
@@ -1,0 +1,6 @@
+sphinx==7.3.6
+doc8==0.10.1
+sphinx_rtd_theme==2.0.0
+sphinxcontrib.spelling==8.0.0
+sphinxcontrib-imagehelper==1.1.1
+GitPython==3.1.41

--- a/.github/workflows/test_colcon.meta
+++ b/.github/workflows/test_colcon.meta
@@ -1,7 +1,7 @@
 {
     "names":
     {
-        "fastrtps":
+        "fastdds":
         {
             "cmake-args":
             [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ list(APPEND CMAKE_PREFIX_PATH ${QT_PATH})
 
 find_package(Qt5 5.15 COMPONENTS Core Widgets Gui Qml Quick Charts QuickControls2 REQUIRED)
 find_package(fastcdr REQUIRED)
-find_package(fastrtps REQUIRED)
+find_package(fastdds REQUIRED)
 find_package(fastdds_statistics_backend REQUIRED)
 
 foreach(c Core Widgets Gui Quick Qml Charts QuickControls2 Utils)
@@ -98,7 +98,7 @@ endforeach()
 if(${fastcdr_FOUND})
     message(STATUS "Fast CDR found!")
 endif()
-if(${fastrtps_FOUND})
+if(${fastdds_FOUND})
     message(STATUS "Fast DDS found!")
 endif()
 if(${fastdds_statistics_backend_FOUND})
@@ -331,7 +331,7 @@ else()
     target_link_libraries(${PROJECT_NAME} PUBLIC
         ${QT5_LIBRARY_LINKS}
         fastcdr
-        fastrtps
+        fastdds
         fastdds_statistics_backend)
 
 endif()

--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -29,8 +29,8 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr)
 endif()
 
-if(NOT fastrtps_FOUND)
-    find_package(fastrtps)
+if(NOT fastdds_FOUND)
+    find_package(fastdds)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -190,7 +190,7 @@ release = u'{}.{}.{}'.format(
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,4 +7,5 @@ sphinx-tabs==3.2.0
 sphinx==4.3.1
 sphinxcontrib-imagehelper==1.1.1
 sphinxcontrib.spelling==7.2.1
-Jinja2<3.1
+Jinja2==3.1
+vcstool==0.3.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ sphinx-tabs==3.2.0
 sphinx==4.3.1
 sphinxcontrib-imagehelper==1.1.1
 sphinxcontrib.spelling==7.2.1
+Jinja2<3.1

--- a/docs/rst/developer_manual/installation/sources/linux.rst
+++ b/docs/rst/developer_manual/installation/sources/linux.rst
@@ -26,7 +26,7 @@ The following packages will be installed:
 
 - ``foonathan_memory_vendor``, an STL compatible C++ memory allocator library.
 - ``fastcdr``, a C++ library that serializes according to the standard CDR serialization mechanism.
-- ``fastrtps``, the core library of eProsima Fast DDS library.
+- ``fastdds``, the core library of eProsima Fast DDS library.
 - ``fastdds_statistics_backend``, a C++ library that provides a simple and easy-to-use API for interacting with data
   from *Fast DDS* statistics module
 

--- a/docs/rst/getting_started/entities.rst
+++ b/docs/rst/getting_started/entities.rst
@@ -44,9 +44,11 @@ Refer to `DomainParticipant Fast DDS Documentation
 <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/domain/domainParticipant/domainParticipant.html>`_
 for a more detailed explanation of the *DomainParticipant* entity in DDS.
 
-Each *DomainParticipant* can only communicate under one *Domain* (see :ref:`logical entities <logical_entities>` section)
-and so it exists a direct connection between each *DomainParticipant* and the *Domain* in which it works.
-From the:numref:`entities diagram <fig_entities_diagram>` it can be seen that *DomainParticipant* entities are contained in a
+Each *DomainParticipant* can only communicate under one *Domain*
+(see :ref:`logical entities <logical_entities>` section) and so it exists a direct connection between each
+*DomainParticipant* and the *Domain* in which it works.
+From the:numref:`entities diagram <fig_entities_diagram>` it can be seen that *DomainParticipant* entities
+are contained in a
 *Process*, this is because a system process (so-called *Process* entity) executes an application using *Fast DDS*
 that instantiates *DomainParticipants*.
 The same applies to *DataReaders/DataWriters* instantiated by a *DomainParticipant* belonging to a specific *Process*.

--- a/docs/rst/getting_started/entities.rst
+++ b/docs/rst/getting_started/entities.rst
@@ -44,9 +44,9 @@ Refer to `DomainParticipant Fast DDS Documentation
 <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/domain/domainParticipant/domainParticipant.html>`_
 for a more detailed explanation of the *DomainParticipant* entity in DDS.
 
-Each *DomainParticipant* can only communicate under one *Domain* (see :ref:`logical_entities`)
+Each *DomainParticipant* can only communicate under one *Domain* (see :ref:`logical entities <logical_entities>` section)
 and so it exists a direct connection between each *DomainParticipant* and the *Domain* in which it works.
-From image :numref:`fig_entities_diagram` it can be seen that *DomainParticipant* entities are contained in a
+From the:numref:`entities diagram <fig_entities_diagram>` it can be seen that *DomainParticipant* entities are contained in a
 *Process*, this is because a system process (so-called *Process* entity) executes an application using *Fast DDS*
 that instantiates *DomainParticipants*.
 The same applies to *DataReaders/DataWriters* instantiated by a *DomainParticipant* belonging to a specific *Process*.

--- a/docs/rst/getting_started/tutorial.rst
+++ b/docs/rst/getting_started/tutorial.rst
@@ -60,7 +60,7 @@ This does not change the Monitor behavior, but would change the data and informa
         PDP_PACKETS_TOPIC;EDP_PACKETS_TOPIC;DISCOVERY_TOPIC;PHYSICAL_DATA_TOPIC;\
         MONITOR_SERVICE_TOPIC"
 
-        ./build/fastrtps/examples/C++/DDS/HelloWorldExample/DDSHelloWorldExample subscriber
+        ./build/fastdds/examples/C++/DDS/HelloWorldExample/DDSHelloWorldExample subscriber
 
     where :code:`subscriber` argument creates a *DomainParticipant* with a *DataReader* in the topic
     :code:`HelloWorldTopic` in *Domain* :code:`0`.
@@ -76,7 +76,7 @@ This does not change the Monitor behavior, but would change the data and informa
         PDP_PACKETS_TOPIC;EDP_PACKETS_TOPIC;DISCOVERY_TOPIC;PHYSICAL_DATA_TOPIC;\
         MONITOR_SERVICE_TOPIC"
 
-        ./build/fastrtps/examples/C++/DDS/HelloWorldExample/DDSHelloWorldExample publisher 0 500
+        ./build/fastdds/examples/C++/DDS/HelloWorldExample/DDSHelloWorldExample publisher 0 500
 
     where :code:`publisher` argument creates a *DomainParticipant* with a *DataWriter* in the topic
     :code:`HelloWorldTopic` in *Domain* :code:`0`.

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -24,16 +24,17 @@ This release includes the following **dependencies update**:
         - New Version
     *   - Fast CDR
         - `eProsima/Fast-CDR <https://github.com/eProsima/Fast-CDR>`_
-        - `v2.1.2 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.1.2>`_
-        - `v2.2.0 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.2.0>`_
+        - `Fast CDR v2.1.2 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.1.2>`_
+        - `Fast CDR v2.2.0 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.2.0>`_
     *   - Fast DDS
         - `eProsima/Fast-DDS <https://github.com/eProsima/Fast-DDS>`_
-        - `v2.13.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.13.0>`_
-        - `v2.14.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.14.0>`_
+        - `Fast DDS v2.13.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.13.0>`_
+        - `Fast DDS v2.14.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.14.0>`_
     *   - Fast DDS Statistics Backend
         - `eProsima/Fast-DDS-statistics-backend <https://github.com/eProsima/Fast-DDS-statistics-backend>`_
-        - `v1.0.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.0.0>`_
-        - `v1.1.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.1.0>`_
+        - `Fast DDS Statistics Backend v1.1.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.1.0>`_
+        - `Fast DDS Statistics Backend v1.0.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.0.0>`_
+
 
 #################
 Previous versions

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -24,16 +24,16 @@ This release includes the following **dependencies update**:
         - New Version
     *   - Fast CDR
         - `eProsima/Fast-CDR <https://github.com/eProsima/Fast-CDR>`_
-        - `Fast CDR v2.1.2 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.1.2>`_
-        - `Fast CDR v2.2.0 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.2.0>`_
+        - `v2.1.2 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.1.2>`__
+        - `v2.2.0 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.2.0>`__
     *   - Fast DDS
         - `eProsima/Fast-DDS <https://github.com/eProsima/Fast-DDS>`_
-        - `Fast DDS v2.13.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.13.0>`_
-        - `Fast DDS v2.14.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.14.0>`_
+        - `v2.13.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.13.0>`__
+        - `v2.14.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.14.0>`__
     *   - Fast DDS Statistics Backend
-        - `eProsima/Fast-DDS-statistics-backend <https://github.com/eProsima/Fast-DDS-statistics-backend>`_
-        - `Fast DDS Statistics Backend v1.1.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.1.0>`_
-        - `Fast DDS Statistics Backend v1.0.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.0.0>`_
+        - `eProsima/Fast-DDS-statistics-backend <https://github.com/eProsima/Fast-DDS-statistics-backend>`__
+        - `v1.1.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.1.0>`__
+        - `v1.0.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.0.0>`__
 
 
 #################

--- a/docs/rst/notes/previous_versions/v2.0.0.rst
+++ b/docs/rst/notes/previous_versions/v2.0.0.rst
@@ -24,13 +24,13 @@ This release includes the following **dependencies update**:
         - New Version
     *   - Fast CDR
         - `eProsima/Fast-CDR <https://github.com/eProsima/Fast-CDR>`_
-        - `Fast CDR v1.1.0 <https://github.com/eProsima/Fast-CDR/releases/tag/v1.1.0>`_
-        - `Fast CDR v2.1.2 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.1.2>`_
+        - `v1.1.0 <https://github.com/eProsima/Fast-CDR/releases/tag/v1.1.0>`__
+        - `v2.1.2 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.1.2>`__
     *   - Fast DDS
         - `eProsima/Fast-DDS <https://github.com/eProsima/Fast-DDS>`_
-        - `Fast DDS v2.11.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.11.0>`_
-        - `Fast DDS v2.13.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.13.0>`_
+        - `v2.11.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.11.0>`__
+        - `v2.13.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.13.0>`__
     *   - Fast DDS Statistics Backend
         - `eProsima/Fast-DDS-statistics-backend <https://github.com/eProsima/Fast-DDS-statistics-backend>`_
-        - `Fast DDS Statistics Backend v0.11.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v0.11.0>`_
-        - `Fast DDS Statistics Backend v1.0.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.0.0>`_
+        - `v0.11.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v0.11.0>`__
+        - `v1.0.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.0.0>`__

--- a/docs/rst/notes/previous_versions/v2.0.0.rst
+++ b/docs/rst/notes/previous_versions/v2.0.0.rst
@@ -14,6 +14,7 @@ This release includes the following **features**:
 
 This release includes the following **dependencies update**:
 
+.. _version_v2.0.0:
 .. list-table::
     :header-rows: 1
 
@@ -23,13 +24,13 @@ This release includes the following **dependencies update**:
         - New Version
     *   - Fast CDR
         - `eProsima/Fast-CDR <https://github.com/eProsima/Fast-CDR>`_
-        - `v1.1.0 <https://github.com/eProsima/Fast-CDR/releases/tag/v1.1.0>`_
-        - `v2.1.2 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.1.2>`_
+        - `Fast CDR v1.1.0 <https://github.com/eProsima/Fast-CDR/releases/tag/v1.1.0>`_
+        - `Fast CDR v2.1.2 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.1.2>`_
     *   - Fast DDS
         - `eProsima/Fast-DDS <https://github.com/eProsima/Fast-DDS>`_
-        - `v2.11.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.11.0>`_
-        - `v2.13.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.13.0>`_
+        - `Fast DDS v2.11.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.11.0>`_
+        - `Fast DDS v2.13.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.13.0>`_
     *   - Fast DDS Statistics Backend
         - `eProsima/Fast-DDS-statistics-backend <https://github.com/eProsima/Fast-DDS-statistics-backend>`_
-        - `v0.11.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v0.11.0>`_
-        - `v1.0.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.0.0>`_
+        - `Fast DDS Statistics Backend v0.11.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v0.11.0>`_
+        - `Fast DDS Statistics Backend v1.0.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.0.0>`_

--- a/docs/rst/ros/galactic/galactic.rst
+++ b/docs/rst/ros/galactic/galactic.rst
@@ -20,7 +20,7 @@ Installation from sources
 Follow the `ROS 2 galactic installation from sources documentation
 <https://docs.ros.org/en/galactic/Installation/Ubuntu-Development-Setup.html>`_
 Fast DDS is downloaded within the rest of the packages.
-The only consideration here is to compile :code:`fastdds` library with the Statistics Module activated.
+The only consideration here is to compile :code:`fastrtps` library with the Statistics Module activated.
 When compiling with colcon, the following arguments must be provided:
 
 .. code-block:: bash
@@ -58,7 +58,7 @@ To execute each of the nodes, run the following commands in different terminals:
 
 .. code-block:: bash
 
-    export RMW_IMPLEMENTATION=rmw_fastdds_cpp
+    export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
 
     export FASTDDS_STATISTICS="HISTORY_LATENCY_TOPIC;NETWORK_LATENCY_TOPIC;\
     PUBLICATION_THROUGHPUT_TOPIC;SUBSCRIPTION_THROUGHPUT_TOPIC;RTPS_SENT_TOPIC;\
@@ -71,7 +71,7 @@ To execute each of the nodes, run the following commands in different terminals:
 
 .. code-block:: bash
 
-    export RMW_IMPLEMENTATION=rmw_fastdds_cpp
+    export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
 
     export FASTDDS_STATISTICS="HISTORY_LATENCY_TOPIC;NETWORK_LATENCY_TOPIC;\
     PUBLICATION_THROUGHPUT_TOPIC;SUBSCRIPTION_THROUGHPUT_TOPIC;RTPS_SENT_TOPIC;\

--- a/docs/rst/ros/galactic/galactic.rst
+++ b/docs/rst/ros/galactic/galactic.rst
@@ -20,7 +20,7 @@ Installation from sources
 Follow the `ROS 2 galactic installation from sources documentation
 <https://docs.ros.org/en/galactic/Installation/Ubuntu-Development-Setup.html>`_
 Fast DDS is downloaded within the rest of the packages.
-The only consideration here is to compile :code:`fastrtps` library with the Statistics Module activated.
+The only consideration here is to compile :code:`fastdds` library with the Statistics Module activated.
 When compiling with colcon, the following arguments must be provided:
 
 .. code-block:: bash
@@ -58,7 +58,7 @@ To execute each of the nodes, run the following commands in different terminals:
 
 .. code-block:: bash
 
-    export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+    export RMW_IMPLEMENTATION=rmw_fastdds_cpp
 
     export FASTDDS_STATISTICS="HISTORY_LATENCY_TOPIC;NETWORK_LATENCY_TOPIC;\
     PUBLICATION_THROUGHPUT_TOPIC;SUBSCRIPTION_THROUGHPUT_TOPIC;RTPS_SENT_TOPIC;\
@@ -71,7 +71,7 @@ To execute each of the nodes, run the following commands in different terminals:
 
 .. code-block:: bash
 
-    export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+    export RMW_IMPLEMENTATION=rmw_fastdds_cpp
 
     export FASTDDS_STATISTICS="HISTORY_LATENCY_TOPIC;NETWORK_LATENCY_TOPIC;\
     PUBLICATION_THROUGHPUT_TOPIC;SUBSCRIPTION_THROUGHPUT_TOPIC;RTPS_SENT_TOPIC;\

--- a/docs/rst/spelling_wordlist.txt
+++ b/docs/rst/spelling_wordlist.txt
@@ -33,3 +33,4 @@ Todo
 unix
 walkthrough
 wget
+numref

--- a/fastdds_monitor.pro
+++ b/fastdds_monitor.pro
@@ -110,12 +110,12 @@ INCLUDEPATH += $$PWD/../../install/fastdds_statistics_backend/include
 DEPENDPATH += $$PWD/../../install/fastdds_statistics_backend/include
 
 # Link to the Fast DDS library
-win32:CONFIG(release, debug|release): LIBS += -L$$PWD/../../install/fastrtps/lib/release/ -lfastrtps
-else:win32:CONFIG(debug, debug|release): LIBS += -L$$PWD/../../install/fastrtps/lib/debug/ -lfastrtps
-else:unix: LIBS += -L$$PWD/../../install/fastrtps/lib/ -lfastrtps
+win32:CONFIG(release, debug|release): LIBS += -L$$PWD/../../install/fastdds/lib/release/ -lfastdds
+else:win32:CONFIG(debug, debug|release): LIBS += -L$$PWD/../../install/fastdds/lib/debug/ -lfastdds
+else:unix: LIBS += -L$$PWD/../../install/fastdds/lib/ -lfastdds
 
-INCLUDEPATH += $$PWD/../../install/fastrtps/include
-DEPENDPATH += $$PWD/../../install/fastrtps/include
+INCLUDEPATH += $$PWD/../../install/fastdds/include
+DEPENDPATH += $$PWD/../../install/fastdds/include
 
 # Link to the Fast CDR library
 win32:CONFIG(release, debug|release): LIBS += -L$$PWD/../../install/fastcdr/lib/release/ -lfastcdr

--- a/include/fastdds_monitor/Controller.h
+++ b/include/fastdds_monitor/Controller.h
@@ -81,7 +81,6 @@ public slots:
 
     //! Slot called when initializing a monitor for a Discovery Server network
     void init_monitor(
-            QString discovery_server_guid_prefix,
             QString discovery_server_locators);
 
     //! Slot called when a Host entity is pressed

--- a/include/fastdds_monitor/Engine.h
+++ b/include/fastdds_monitor/Engine.h
@@ -150,7 +150,6 @@ public:
      * @param domain number of the domain
      */
     void init_monitor(
-            QString discovery_server_guid_prefix,
             QString discovery_server_locators);
 
     /////

--- a/include/fastdds_monitor/backend/SyncBackendConnection.h
+++ b/include/fastdds_monitor/backend/SyncBackendConnection.h
@@ -95,7 +95,6 @@ public:
      * @return EntityId of the new Domain Entity created
      */
     EntityId init_monitor(
-            std::string discovery_server_guid_prefix,
             std::string discovery_server_locators);
 
     /////

--- a/mock/CMakeLists.txt
+++ b/mock/CMakeLists.txt
@@ -26,7 +26,7 @@ cmake_minimum_required(VERSION 3.5)
 option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 
 find_package(fastcdr REQUIRED)
-find_package(fastrtps REQUIRED)
+find_package(fastdds REQUIRED)
 find_package(fastdds_statistics_backend REQUIRED)
 
 ###############################################################################

--- a/mock/complex_mock/CMakeLists.txt
+++ b/mock/complex_mock/CMakeLists.txt
@@ -21,7 +21,7 @@ project(complex-backend-mock)
 
 # Find FastDDS Statistics Backend library
 find_package(fastcdr REQUIRED)
-find_package(fastrtps REQUIRED)
+find_package(fastdds REQUIRED)
 find_package(fastdds_statistics_backend REQUIRED)
 
 # Allow to use threads

--- a/mock/static_mock/CMakeLists.txt
+++ b/mock/static_mock/CMakeLists.txt
@@ -21,7 +21,7 @@ project(static-backend-mock)
 
 # Find FastDDS Statistics Backend library
 find_package(fastcdr REQUIRED)
-find_package(fastrtps REQUIRED)
+find_package(fastdds REQUIRED)
 find_package(fastdds_statistics_backend REQUIRED)
 
 # Allow to use threads

--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,7 @@
   <url type="repository">https://github.com/eProsima/Fast-DDS-monitor</url>
 
   <depend>fastcdr</depend>
-  <depend>fastrtps</depend>
+  <depend>fastdds</depend>
   <depend>fastdds_statistics_backend</depend>
 
   <buildtool_depend>cmake</buildtool_depend>

--- a/qml/InitDSMonitorDialog.qml
+++ b/qml/InitDSMonitorDialog.qml
@@ -38,7 +38,6 @@ Dialog {
     }
 
     onReset: {
-        discoveryServerGuid.text = "44.53.00.5f.45.50.52.4f.53.49.4d.41"
         discoveryServerLocatorsModel.clear()
         discoveryServerLocatorsModel.append({"transportProtocolIdx": 0, "ip": "127.0.0.1", "port": 11811})
     }
@@ -57,26 +56,9 @@ Dialog {
         anchors.fill: parent
 
         Label {
-            text: 'Set the GUID and the network addresses (locators) of a Discovery Server.'
+            text: 'Set the network addresses (locators) of a Discovery Server.'
         }
 
-        ColumnLayout {
-            Layout.fillWidth: true
-            Label {
-                id: discoveryServerGuidLabel
-                text: "• Discovery Server GUID: "
-                InfoToolTip {
-                    text: 'Discovery Server GUID.'
-                }
-            }
-            TextField {
-                id: discoveryServerGuid
-                placeholderText: "GUID example: 44.53.00.5f.45.50.52.4f.53.49.4d.41"
-                implicitWidth: dialogLayout.width
-                text: "44.53.00.5f.45.50.52.4f.53.49.4d.41"
-                selectByMouse: true
-            }
-        }
         GridLayout {
             Layout.fillWidth: true
             columns: 5
@@ -85,7 +67,6 @@ Dialog {
             Label {
                 id: discoveryServerLocatorLabel
                 Layout.columnSpan: parent.columns
-                text: "• Discovery Server locator(s): "
                 InfoToolTip {
                     text: 'Each row defines a locator\n' +
                           'for the Discovery Server.'
@@ -311,15 +292,6 @@ Dialog {
     }
 
     MessageDialog {
-        id: wrongGuid
-        title: "Invalid Discovery Server GUID"
-        icon: StandardIcon.Warning
-        standardButtons:  StandardButton.Retry | StandardButton.Discard
-        text: "The inserted Discovery Server GUID is not valid."
-        onAccepted: initDSMonitorDialog.open()
-    }
-
-    MessageDialog {
         id: wrongLocator
         title: "Invalid Discovery Server Locator"
         icon: StandardIcon.Warning
@@ -365,14 +337,6 @@ Dialog {
     }
 
     /**
-     * Returns an regular expression for Discovery Server GUID
-     */
-    function guidRegex() {
-        var guidRe =  /^(([0-9a-fA-F]{1,2}\.){11})([0-9a-fA-F]{1,2})$/
-        return guidRe
-    }
-
-    /**
      * Returns an regular expression that matches any string
      */
     function matchAllRegex() {
@@ -384,14 +348,6 @@ Dialog {
      * Function to parse the input parameter of the initialize monitor dialog for Discovery Server
      */
     function initDiscoveryServer() {
-        /////
-        // Check that Discovery Server GUID is correct
-        var guidRe = guidRegex()
-        if (!guidRe.test(discoveryServerGuid.text)) {
-            wrongGuid.open()
-            return
-        }
-
         /////
         // Build the locators
         var locators = []
@@ -448,7 +404,7 @@ Dialog {
                 return
             }
 
-            controller.init_monitor(discoveryServerGuid.text, locators.join(';'))
+            controller.init_monitor(locators.join(';'))
         }
     }
 

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -21,7 +21,7 @@
 
 #include <fastdds_monitor/config.h>
 #include <fastdds_statistics_backend/config.h>
-#include <fastrtps/config.h>
+#include <fastdds/config.hpp>
 
 #include <fastdds_monitor/Controller.h>
 #include <fastdds_monitor/Engine.h>
@@ -34,10 +34,9 @@ void Controller::init_monitor(
 }
 
 void Controller::init_monitor(
-        QString discovery_server_guid_prefix,
         QString discovery_server_locators)
 {
-    engine_->init_monitor(discovery_server_guid_prefix, discovery_server_locators);
+    engine_->init_monitor(discovery_server_locators);
 }
 
 void Controller::host_click(
@@ -170,7 +169,7 @@ QtCharts::QVXYModelMapper* Controller::add_statistics_data(
 
 QString Controller::fastdds_version()
 {
-    return utils::to_QString(FASTRTPS_VERSION_STR);
+    return utils::to_QString(FASTDDS_VERSION_STR);
 }
 
 QString Controller::fastdds_statistics_backend_version()

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -266,13 +266,11 @@ void Engine::init_monitor(
 }
 
 void Engine::init_monitor(
-        QString discovery_server_guid_prefix,
         QString discovery_server_locators)
 {
     std::lock_guard<std::recursive_mutex> lock(initializing_monitor_);
 
     backend::EntityId domain_id = backend_connection_.init_monitor(
-        utils::to_string(discovery_server_guid_prefix),
         utils::to_string(discovery_server_locators));
 
     if (domain_id.is_valid())
@@ -282,9 +280,7 @@ void Engine::init_monitor(
     else
     {
         process_error(
-            "Error trying to initialize monitor in Discovery Server with GUID " +
-            utils::to_string(discovery_server_guid_prefix) +
-            " and locators " + utils::to_string(discovery_server_locators),
+            "Error trying to initialize monitor in Discovery Server with locators: " + utils::to_string(discovery_server_locators),
             ErrorType::INIT_DS_MONITOR);
     }
 }

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -458,13 +458,11 @@ EntityId SyncBackendConnection::init_monitor(
 }
 
 EntityId SyncBackendConnection::init_monitor(
-        std::string discovery_server_guid_prefix,
         std::string discovery_server_locators)
 {
     try
     {
         return StatisticsBackend::init_monitor(
-            discovery_server_guid_prefix,
             discovery_server_locators,
             nullptr, CallbackMask::all(), DataKindMask::none(), FASTDDS_MONITOR_APP);
     }

--- a/test/blackbox/static_mock/CMakeLists.txt
+++ b/test/blackbox/static_mock/CMakeLists.txt
@@ -46,7 +46,7 @@ target_include_directories(BlackboxStaticMockTest PRIVATE
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/${PROJECT_NAME}>)
 
 target_link_libraries(BlackboxStaticMockTest
-    fastrtps
+    fastdds
     fastcdr
     ${QT5_LIBRARY_LINKS}
     fastdds_statistics_backend

--- a/test/unittest/backend/CMakeLists.txt
+++ b/test/unittest/backend/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(SyncBackendConnectionTest PRIVATE
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/${PROJECT_NAME}>)
 
 target_link_libraries(SyncBackendConnectionTest PUBLIC
-    fastrtps
+    fastdds
     fastcdr
     fastdds_statistics_backend
     ${QT5_LIBRARY_LINKS}

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -89,7 +89,7 @@ target_include_directories(BackendUtilsTest PRIVATE
     ${PROJECT_SOURCE_DIR}/include)
 
 target_link_libraries(BackendUtilsTest PUBLIC
-    fastrtps
+    fastdds
     fastcdr
     fastdds_statistics_backend
     ${QT5_LIBRARY_LINKS}


### PR DESCRIPTION
 Add minor changes for Monitor compilation with Fast DDS v3. Fast DDS Statistics Backend migration to Fast DDS v3 (https://github.com/eProsima/Fast-DDS-statistics-backend/pull/239) required.  

**Related PRs**
- https://github.com/eProsima/Fast-DDS-statistics-backend/pull/239