### PR TITLE
Reference previous version v2.1.0 in the documentation

### DIFF
--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -44,6 +44,7 @@ This release includes the following **dependencies update**:
 Previous versions
 #################
 
+.. include:: previous_versions/v2.1.0.rst
 .. include:: previous_versions/v2.0.0.rst
 .. include:: previous_versions/v1.5.0.rst
 .. include:: previous_versions/v1.4.0.rst

--- a/docs/rst/spelling_wordlist.txt
+++ b/docs/rst/spelling_wordlist.txt
@@ -33,4 +33,3 @@ Todo
 unix
 walkthrough
 wget
-numref


### PR DESCRIPTION
This PR includes a reference to the previous version v2.1.0 release notes.
This fixes doc CI.