### PR TITLE
Bump version to v3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 # Version
 ###############################################################################
 set(PRODUCT_MAJOR_VERSION 3)
-set(PRODUCT_MINOR_VERSION 0)
+set(PRODUCT_MINOR_VERSION 1)
 set(PRODUCT_PATCH_VERSION 0)
 set(PRODUCT_VERSION_STR ${PRODUCT_MAJOR_VERSION}.${PRODUCT_MINOR_VERSION}.${PRODUCT_PATCH_VERSION})
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -25,7 +25,7 @@ cmake_policy(VERSION 3.5...3.13)
 # Version
 ###############################################################################
 set(PRODUCT_MAJOR_VERSION 3)
-set(PRODUCT_MINOR_VERSION 0)
+set(PRODUCT_MINOR_VERSION 1)
 set(PRODUCT_PATCH_VERSION 0)
 set(PRODUCT_VERSION_STR ${PRODUCT_MAJOR_VERSION}.${PRODUCT_MINOR_VERSION}.${PRODUCT_PATCH_VERSION})
 

--- a/docs/rst/getting_started/entities.rst
+++ b/docs/rst/getting_started/entities.rst
@@ -47,7 +47,7 @@ for a more detailed explanation of the *DomainParticipant* entity in DDS.
 Each *DomainParticipant* can only communicate under one *Domain*
 (see :ref:`logical entities <logical_entities>` section) and so it exists a direct connection between each
 *DomainParticipant* and the *Domain* in which it works.
-From the:numref:`entities diagram <fig_entities_diagram>` it can be seen that *DomainParticipant* entities
+From the :numref:`entities diagram <fig_entities_diagram>` it can be seen that *DomainParticipant* entities
 are contained in a
 *Process*, this is because a system process (so-called *Process* entity) executes an application using *Fast DDS*
 that instantiates *DomainParticipants*.

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -4,18 +4,8 @@
 .. .. include:: forthcoming_version.rst
 
 ##############
-Version v3.0.0
+Version v3.1.0
 ##############
-
-This release includes the following **new features**:
-
-* Get IDL type definition of a topic.
-
-This release includes the following **updates**:
-
-* Update to Fast DDS v3.0.1.
-* Include Fast DDS Visualizer as recognized application.
-* Show tab names on hover event for long names representation.
 
 This release includes the following **dependencies update**:
 
@@ -28,22 +18,23 @@ This release includes the following **dependencies update**:
         - New Version
     *   - Fast CDR
         - `eProsima/Fast-CDR <https://github.com/eProsima/Fast-CDR>`_
-        - `v2.2.0 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.2.0>`__
         - `v2.2.4 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.2.4>`__
+        - `v2.2.5 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.2.5>`__
     *   - Fast DDS
         - `eProsima/Fast-DDS <https://github.com/eProsima/Fast-DDS>`_
-        - `v2.14.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.14.0>`__
         - `v3.0.1 <https://github.com/eProsima/Fast-DDS/releases/tag/v3.0.1>`__
+        - `v3.1.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v3.1.0>`__
     *   - Fast DDS Statistics Backend
         - `eProsima/Fast-DDS-statistics-backend <https://github.com/eProsima/Fast-DDS-statistics-backend>`__
-        - `v1.1.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.1.0>`__
         - `v2.0.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v2.0.0>`__
+        - `v2.1.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v2.1.0>`__
 
 
 #################
 Previous versions
 #################
 
+.. include:: previous_versions/v3.0.0.rst
 .. include:: previous_versions/v2.1.0.rst
 .. include:: previous_versions/v2.0.0.rst
 .. include:: previous_versions/v1.5.0.rst

--- a/docs/rst/notes/previous_versions/v3.0.0.rst
+++ b/docs/rst/notes/previous_versions/v3.0.0.rst
@@ -1,0 +1,34 @@
+Version v3.0.0
+==============
+
+This release includes the following **new features**:
+
+* Get IDL type definition of a topic.
+
+This release includes the following **updates**:
+
+* Update to Fast DDS v3.0.1.
+* Include Fast DDS Visualizer as recognized application.
+* Show tab names on hover event for long names representation.
+
+This release includes the following **dependencies update**:
+
+.. list-table::
+    :header-rows: 1
+
+    *   -
+        - Repository
+        - Old Version
+        - New Version
+    *   - Fast CDR
+        - `eProsima/Fast-CDR <https://github.com/eProsima/Fast-CDR>`_
+        - `v2.2.0 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.2.0>`__
+        - `v2.2.4 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.2.4>`__
+    *   - Fast DDS
+        - `eProsima/Fast-DDS <https://github.com/eProsima/Fast-DDS>`_
+        - `v2.14.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v2.14.0>`__
+        - `v3.0.1 <https://github.com/eProsima/Fast-DDS/releases/tag/v3.0.1>`__
+    *   - Fast DDS Statistics Backend
+        - `eProsima/Fast-DDS-statistics-backend <https://github.com/eProsima/Fast-DDS-statistics-backend>`__
+        - `v1.1.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v1.1.0>`__
+        - `v2.0.0 <https://github.com/eProsima/Fast-DDS-statistics-backend/releases/tag/v2.0.0>`__

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,6 @@
   <maintainer email="RaulSanchezMateos@eprosima.com">Raul Sánchez-Mateos</maintainer>
   <maintainer email="juanlopez@eprosima.com">Juan López</maintainer>
   <maintainer email="jesuspoderoso@eprosima.com">Jesús Poderoso</maintainer>
-  <maintainer email="irenebandera@eprosima.com">Irene Bandera</maintainer>
   <maintainer email="jesusperez@eprosima.com">Jesús Pérez</maintainer>
   <license file="LICENSE">GNU general public license</license>
 

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>fastdds_monitor</name>
   <!-->There must be a release. Update version accordingly<-->
-  <version>3.0.0</version>
+  <version>3.1.0</version>
   <description>
     Qt application written in C++ that plot the data from the Fast DDS Statistics Backend.
   </description>

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1058,7 +1058,7 @@ bool Engine::update_entity_status(
                 {
                     if (sample.status != backend::StatusLevel::OK_STATUS)
                     {
-                        std::string fastdds_version = "v3.0.1";
+                        std::string fastdds_version = "v3.1.0";
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
                             id, backend_connection_.get_name(id), entity_status, description);


### PR DESCRIPTION
This PR bumps the Fast DDS Monitor version to v3.1.0, and updates its release notes.

This PR is on top of and must be merged after:
- #236 