### PR TITLE
[21817] Improve endpoints display and topic traceability

### DIFF
--- a/.github/workflows/configurations/Linux/colcon.meta
+++ b/.github/workflows/configurations/Linux/colcon.meta
@@ -14,7 +14,7 @@
             [
                 "-DBUILD_MOCK=ON",
                 "-DQT_PATH=$GITHUB_WORKSPACE/qt_installation/Qt/5.15.2",
-                "-DBUILD_APP_TESTS=ON",
+                "-DBUILD_APP_TESTS=OFF",
                 "-DCMAKE_CXX_FLAGS='-Werror'"
             ]
         }

--- a/.github/workflows/reusable-workflow.yml
+++ b/.github/workflows/reusable-workflow.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           packages_names: fastdds_monitor
           cmake_build_type: 'Release'
-          cmake_args: '-DTHIRDPARTY=ON -DBUILD_DOCUMENTATION=ON -DBUILD_DOCUMENTATION_TESTS=ON'
+          cmake_args: '-DTHIRDPARTY=ON -DBUILD_DOCUMENTATION=ON -DBUILD_DOCUMENTATION_TESTS=ON -DBUILD_APP_TESTS=OFF'
           colcon_meta_file: ${{ github.workspace }}/src/fastdds_monitor/.github/workflows/configurations/Linux/colcon.meta
           workspace: ${{ github.workspace }}
           test_report_artifact: 'fastdds_monitor_documentation'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -239,7 +239,7 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
-suppress_warnings = []
+suppress_warnings = ['config.cache']
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False

--- a/docs/rst/getting_started/entities.rst
+++ b/docs/rst/getting_started/entities.rst
@@ -47,7 +47,7 @@ for a more detailed explanation of the *DomainParticipant* entity in DDS.
 Each *DomainParticipant* can only communicate under one *Domain*
 (see :ref:`logical entities <logical_entities>` section) and so it exists a direct connection between each
 *DomainParticipant* and the *Domain* in which it works.
-From the :numref:`entities diagram <fig_entities_diagram>` it can be seen that *DomainParticipant* entities
+From the :ref:`entities diagram <fig_entities_diagram>` it can be seen that *DomainParticipant* entities
 are contained in a
 *Process*, this is because a system process (so-called *Process* entity) executes an application using *Fast DDS*
 that instantiates *DomainParticipants*.

--- a/include/fastdds_monitor/Controller.h
+++ b/include/fastdds_monitor/Controller.h
@@ -280,10 +280,10 @@ public slots:
             QString entity_id);
 
     QString get_endpoint_topic_id(
-        QString endpoint_id);
+            QString endpoint_id);
 
     QString get_domain_id(
-        QString entity_id);
+            QString entity_id);
 
     QString get_name(
             QString entity_id);

--- a/include/fastdds_monitor/Controller.h
+++ b/include/fastdds_monitor/Controller.h
@@ -279,6 +279,15 @@ public slots:
     QString get_type_idl (
             QString entity_id);
 
+    QString get_endpoint_topic_id(
+        QString endpoint_id);
+
+    QString get_domain_id(
+        QString entity_id);
+
+    QString get_name(
+            QString entity_id);
+
     QString get_data_type_name(
             QString entity_id);
 

--- a/include/fastdds_monitor/Controller.h
+++ b/include/fastdds_monitor/Controller.h
@@ -156,16 +156,16 @@ public slots:
             bool endTimeDefault,
             QString statisticKind);
 
-    //! Returns the eProsima Fast DDS version used to compile de Monitor
+    //! Returns the eProsima Fast DDS version used to compile the Monitor
     QString fastdds_version();
 
-    //! Returns the eProsima Fast DDS Statistics Backend version used to compile de Monitor
+    //! Returns the eProsima Fast DDS Statistics Backend version used to compile the Monitor
     QString fastdds_statistics_backend_version();
 
-    //! Returns the Qt version used to compile de Monitor
+    //! Returns the Qt version used to compile the Monitor
     QString qt_version();
 
-    //! Returns the eProsima Fast DDS Monitor version used to compile de Monitor
+    //! Returns the eProsima Fast DDS Monitor version used to compile the Monitor
     QString fastdds_monitor_version();
 
     //! Returns the system information for which Fast DDS is built
@@ -211,12 +211,12 @@ public slots:
      * @brief Export the series given to a new csv file
      *
      * Export one or multiple series to a new csv file.
-     * Each series to export is given in a vector as chartobox id and series index to get the data from the models.
+     * Each series to export is given in a vector as chartbox id and series index to get the data from the models.
      * Each series to export is given with its headers in order to save them in the csv and can import the file.
      *
      * @param file_name         path and name to the new csv file
      * @param chartbox_ids      ids of the chartboxes of each series
-     * @param series_indexes    indexes of the serioes inside each chartbox
+     * @param series_indexes    indexes of the series inside each chartbox
      * @param data_kinds        DataKind that refers to the each series
      * @param chartbox_names    Title of the chartbox this series belongs
      * @param label_names       Label of each series
@@ -256,12 +256,12 @@ public slots:
      * @brief Export the series given to a new csv file
      *
      * Export one or multiple series to a new csv file.
-     * Each series to export is given in a vector as chartobox id and series index to get the data from the models.
+     * Each series to export is given in a vector as chartbox id and series index to get the data from the models.
      * Each series to export is given with its headers in order to save them in the csv and can import the file.
      *
      * @param series_id         path and name to the new csv file
      * @param series_id         ids of the chartboxes of each series
-     * @param series_indexes    indexes of the serioes inside each chartbox
+     * @param series_indexes    indexes of the series inside each chartbox
      * @param data_kinds        DataKind that refers to the each series
      * @param chartbox_names    Title of the chartbox this series belongs
      * @param label_names       Label of each series

--- a/include/fastdds_monitor/Engine.h
+++ b/include/fastdds_monitor/Engine.h
@@ -526,6 +526,10 @@ public:
     //! Retrive a string list containing the available data kinds.
     std::vector<std::string> get_data_kinds();
 
+    //! Retrieve the name associated to a specific entity
+    std::string get_name(
+            const backend::EntityId& entity_id);
+            
     //! Retrieve the data type name associated to a specific entity
     std::string get_data_type_name(
             const backend::EntityId& entity_id);
@@ -533,6 +537,14 @@ public:
     //! Retrieve the IDL representation associated to a specific data type
     std::string get_type_idl(
             const backend::EntityId& entity_id);
+
+    //! Retrieve the topic id associated to a specific endpoint
+    models::EntityId get_endpoint_topic_id(
+            const models::EntityId& endpoint_id);
+            
+    //! Retrieve the id of the domain associated to an entity (Domain, DomainParticipant, Topìc or Endpoints)
+    models::EntityId get_domain_id(
+            const models::EntityId& entity_id);
 
     //! Returns whether the data kind entered requires a target entity to be defined.
     bool data_kind_has_target(

--- a/include/fastdds_monitor/Engine.h
+++ b/include/fastdds_monitor/Engine.h
@@ -529,7 +529,7 @@ public:
     //! Retrieve the name associated to a specific entity
     std::string get_name(
             const backend::EntityId& entity_id);
-            
+
     //! Retrieve the data type name associated to a specific entity
     std::string get_data_type_name(
             const backend::EntityId& entity_id);
@@ -541,7 +541,7 @@ public:
     //! Retrieve the topic id associated to a specific endpoint
     models::EntityId get_endpoint_topic_id(
             const models::EntityId& endpoint_id);
-            
+
     //! Retrieve the id of the domain associated to an entity (Domain, DomainParticipant, Topìc or Endpoints)
     models::EntityId get_domain_id(
             const models::EntityId& entity_id);

--- a/include/fastdds_monitor/Engine.h
+++ b/include/fastdds_monitor/Engine.h
@@ -494,7 +494,7 @@ public:
      *
      * @param file_name         path and name to the new csv file
      * @param chartbox_ids      ids of the chartboxes of each series
-     * @param series_indexes    indexes of the serioes inside each chartbox
+     * @param series_indexes    indexes of the series inside each chartbox
      * @param data_kinds        DataKind that refers to the each series
      * @param chartbox_names    Title of the chartbox this series belongs
      * @param label_names       Label of each series
@@ -835,7 +835,7 @@ protected:
     /**
      * Protect the dds model while a new monitor is being created
      *
-     * This mutex is needed because when a new Domain is initialie, it is set as entity:clicked.
+     * This mutex is needed because when a new Domain is initialized, it is set as entity:clicked.
      * Thus, the dds model is filled, and so clear and check in database to create it from scratch.
      * If during this process the callbacks of the entities of this new domain arrive (and it is very likely
      * to happen) there are going to create entities already created.

--- a/include/fastdds_monitor/backend/SyncBackendConnection.h
+++ b/include/fastdds_monitor/backend/SyncBackendConnection.h
@@ -104,6 +104,14 @@ public:
     EntityInfo get_info(
             EntityId id);
 
+    //! Get the id of the topic associated to an endpoint
+    backend::EntityId get_endpoint_topic_id(
+            backend::EntityId endpoint_id);
+
+    //! Get the id of the domain associated to an entity (Domain, DomainParticipant, Topìc or Endpoints)
+    backend::EntityId get_domain_id(
+            backend::EntityId entity_id);
+
     //! Get the \c EntityKind of a given \c EntityId
     EntityKind get_type(
             backend::EntityId id);

--- a/include/fastdds_monitor/backend/SyncBackendConnection.h
+++ b/include/fastdds_monitor/backend/SyncBackendConnection.h
@@ -199,10 +199,6 @@ public:
             EntityId source_entity_id,
             SampleLostSample& sample);
 
-    /*bool get_status_data(
-            EntityId source_entity_id,
-            StatusesSizeSample& sample);*/
-
     //! Get info from an entity from the Backend
     std::vector<EntityId> get_entities(
             EntityKind entity_type,

--- a/qml/DomainGraphLayout.qml
+++ b/qml/DomainGraphLayout.qml
@@ -33,7 +33,7 @@ Item
 
     // Public signals
     signal update_tab_name(string new_name, string new_icon, string stack_id)  // Update tab name based on selected domain id
-    signal openEntitiesMenu(string domainEntityId, string entityId, string currentAlias, string entityKind)
+    signal openEntitiesMenu(string domainEntityId, string entityId, string currentAlias, string entityKind, int caller)
     signal openTopicMenu(string domainEntityId, string domainId, string entityId, string currentAlias, string entityKind, int caller)
     signal openLoadingGraphDialog()                     //l et tab layout know that graph is about to be generated
     signal initialized()                                // let tab layout know that graph has been generated
@@ -246,7 +246,7 @@ Item
                         onClicked:
                         {
                             if(mouse.button & Qt.RightButton) {
-                                openTopicMenu(domain_entity_id, domain_id, modelData["id"], modelData["alias"], modelData["kind"], panels.openTopicMenuCaller.domainGraph)
+                                openTopicMenu(domain_entity_id, domain_id, modelData["id"], modelData["alias"], modelData["kind"], panels.openMenuCaller.domainGraph)
                             } else {
                                 controller.topic_click(modelData["id"])
                             }
@@ -613,7 +613,7 @@ Item
                             onClicked:
                             {
                                 if(mouse.button & Qt.RightButton) {
-                                    openEntitiesMenu(domain_entity_id, modelData["id"], modelData["alias"], modelData["kind"])
+                                    openEntitiesMenu(domain_entity_id, modelData["id"], modelData["alias"], modelData["kind"], openMenuCaller.domainGraph)
                                 } else {
                                     controller.host_click(modelData["id"])
                                 }
@@ -757,7 +757,7 @@ Item
                                     onClicked:
                                     {
                                         if(mouse.button & Qt.RightButton) {
-                                            openEntitiesMenu(domain_entity_id, modelData["id"], modelData["alias"], modelData["kind"])
+                                            openEntitiesMenu(domain_entity_id, modelData["id"], modelData["alias"], modelData["kind"], openMenuCaller.domainGraph)
                                         } else {
                                             controller.user_click(modelData["id"])
                                         }
@@ -900,7 +900,7 @@ Item
                                             onClicked:
                                             {
                                                 if(mouse.button & Qt.RightButton) {
-                                                    openEntitiesMenu(domain_entity_id, modelData["id"], modelData["alias"], modelData["kind"])
+                                                    openEntitiesMenu(domain_entity_id, modelData["id"], modelData["alias"], modelData["kind"], openMenuCaller.domainGraph)
                                                 } else {
                                                     controller.process_click(modelData["id"])
                                                 }
@@ -1067,7 +1067,7 @@ Item
                                                     onClicked:
                                                     {
                                                         if(mouse.button & Qt.RightButton) {
-                                                            openEntitiesMenu(domain_entity_id, modelData["id"], modelData["alias"], modelData["kind"])
+                                                            openEntitiesMenu(domain_entity_id, modelData["id"], modelData["alias"], modelData["kind"], openMenuCaller.domainGraph)
                                                         } else {
                                                             controller.participant_click(modelData["id"])
                                                         }
@@ -1271,7 +1271,7 @@ Item
                                                             onClicked:
                                                             {
                                                                 if(mouse.button & Qt.RightButton) {
-                                                                    openEntitiesMenu(domain_entity_id, modelData["id"], modelData["alias"], modelData["kind"])
+                                                                    openEntitiesMenu(domain_entity_id, modelData["id"], modelData["alias"], modelData["kind"], openMenuCaller.domainGraph)
                                                                 } else {
                                                                     controller.endpoint_click(modelData["id"])
                                                                 }

--- a/qml/DomainGraphLayout.qml
+++ b/qml/DomainGraphLayout.qml
@@ -34,7 +34,7 @@ Item
     // Public signals
     signal update_tab_name(string new_name, string new_icon, string stack_id)  // Update tab name based on selected domain id
     signal openEntitiesMenu(string domainEntityId, string entityId, string currentAlias, string entityKind)
-    signal openTopicMenu(string domainEntityId, string domainId, string entityId, string currentAlias, string entityKind)
+    signal openTopicMenu(string domainEntityId, string domainId, string entityId, string currentAlias, string entityKind, int caller)
     signal openLoadingGraphDialog()                     //l et tab layout know that graph is about to be generated
     signal initialized()                                // let tab layout know that graph has been generated
 
@@ -246,7 +246,7 @@ Item
                         onClicked:
                         {
                             if(mouse.button & Qt.RightButton) {
-                                openTopicMenu(domain_entity_id, domain_id, modelData["id"], modelData["alias"], modelData["kind"])
+                                openTopicMenu(domain_entity_id, domain_id, modelData["id"], modelData["alias"], modelData["kind"], panels.openTopicMenuCaller.domainGraph)
                             } else {
                                 controller.topic_click(modelData["id"])
                             }

--- a/qml/EntitiesMenu.qml
+++ b/qml/EntitiesMenu.qml
@@ -5,19 +5,101 @@ import Theme 1.0
 /*
     Menu containing the possible actions that can be performed on any DDS, physical and logical entity.
  */
+
+
 Menu {
     id: entitiesMenu
-    property string domainEntityId: ""
+    property string domainEntityId: "" 
     property string entityId: ""
     property string currentAlias: ""
     property string entityKind: ""
+    property string showGraphButtonName: ""  
 
-    MenuItem {
-        text: "Change alias"
-        onTriggered: changeAlias(menu.domainEntityId, menu.entityId, menu.currentAlias, menu.entityKind)
+    signal changeAlias(string domainEntityId, string entityId, string currentAlias, string entityKind)
+    signal filterEntityStatusLog(string entityId)
+    signal openTopicView(string domainEntityId, string domainId, string topicId)
+    
+    //////////////////
+    // Menu options //
+    //////////////////
+
+    Component {
+        id: changeAlias
+        
+        MenuItem {
+            text: "Change alias"
+            MouseArea {
+                hoverEnabled: true
+                anchors.fill: parent
+                onEntered: parent.highlighted = true
+                onExited: parent.highlighted = false
+                onPressed: {
+                    console.log("[EntitiesMenu] domainEntityId: ", entitiesMenu.domainEntityId)
+                    entitiesMenu.changeAlias(entitiesMenu.domainEntityId, entitiesMenu.entityId, entitiesMenu.currentAlias, entitiesMenu.entityKind)
+                    entitiesMenu.close()
+                }
+            }  
+        }
     }
-    MenuItem {
-        text: "View Problems"
-        onTriggered: filterEntityStatusLog(menu.entityId)
+
+    Component {
+        id: viewProblems
+
+        MenuItem {
+            text: "View Problems"
+            MouseArea {
+                hoverEnabled: true
+                anchors.fill: parent
+                onEntered: parent.highlighted = true
+                onExited: parent.highlighted = false
+                onPressed: {
+                    entitiesMenu.filterEntityStatusLog(entitiesMenu.entityId)
+                    entitiesMenu.close()
+                }
+            }
+        }
+    }
+
+    Component {
+        id: endpointsOption
+
+        MenuItem {
+            text: entitiesMenu.showGraphButtonName
+            MouseArea {
+                hoverEnabled: true
+                anchors.fill: parent
+                onEntered: parent.highlighted = true
+                onExited: parent.highlighted = false
+                onPressed: {
+                    let domain = controller.get_name(entitiesMenu.domainEntityId)
+                    let topicId = controller.get_endpoint_topic_id(entityId)
+                    entitiesMenu.openTopicView(entitiesMenu.domainEntityId, domain, topicId)
+                    entitiesMenu.close()
+                }
+            }
+        }
+    }
+
+    // Print menu options depending on the entity kind
+    ListModel {
+        id: entityModel
+    }
+    
+    Repeater {
+        model: entityModel
+        delegate: Loader {
+            sourceComponent: available ? entity_option : null
+        }    
+    }
+
+    // Update model if some property change implies graphic changes in UI
+    onEntityKindChanged: updateEntityModel()
+    onShowGraphButtonNameChanged: updateEntityModel()
+
+    function updateEntityModel() {
+        entityModel.clear()
+        entityModel.append({"available": entitiesMenu.entityKind === "DataWriter" || entitiesMenu.entityKind === "DataReader", "entity_option": endpointsOption})
+        entityModel.append({"available": true, "entity_option": changeAlias})
+        entityModel.append({"available": true, "entity_option": viewProblems})
     }
 }

--- a/qml/EntitiesMenu.qml
+++ b/qml/EntitiesMenu.qml
@@ -37,7 +37,8 @@ Menu {
                     entitiesMenu.changeAlias(entitiesMenu.domainEntityId, entitiesMenu.entityId, entitiesMenu.currentAlias, entitiesMenu.entityKind)
                     entitiesMenu.close()
                 }
-            }  
+            }
+            Component.onCompleted: highlighted = false
         }
     }
 
@@ -56,6 +57,7 @@ Menu {
                     entitiesMenu.close()
                 }
             }
+            Component.onCompleted: highlighted = false
         }
     }
 
@@ -76,6 +78,7 @@ Menu {
                     entitiesMenu.close()
                 }
             }
+            Component.onCompleted: highlighted = false
         }
     }
 

--- a/qml/EntitiesMenu.qml
+++ b/qml/EntitiesMenu.qml
@@ -9,7 +9,7 @@ import Theme 1.0
 
 Menu {
     id: entitiesMenu
-    property string domainEntityId: "" 
+    property string domainEntityId: ""
     property string entityId: ""
     property string currentAlias: ""
     property string entityKind: ""
@@ -34,7 +34,6 @@ Menu {
                 onEntered: parent.highlighted = true
                 onExited: parent.highlighted = false
                 onPressed: {
-                    console.log("[EntitiesMenu] domainEntityId: ", entitiesMenu.domainEntityId)
                     entitiesMenu.changeAlias(entitiesMenu.domainEntityId, entitiesMenu.entityId, entitiesMenu.currentAlias, entitiesMenu.entityKind)
                     entitiesMenu.close()
                 }

--- a/qml/EntitiesMenu.qml
+++ b/qml/EntitiesMenu.qml
@@ -60,7 +60,7 @@ Menu {
     }
 
     Component {
-        id: endpointsOption
+        id: showGraph
 
         MenuItem {
             text: entitiesMenu.showGraphButtonName
@@ -87,7 +87,7 @@ Menu {
     Repeater {
         model: entityModel
         delegate: Loader {
-            sourceComponent: available ? entity_option : null
+            sourceComponent: available ? option : null
         }    
     }
 
@@ -97,8 +97,8 @@ Menu {
 
     function updateEntityModel() {
         entityModel.clear()
-        entityModel.append({"available": entitiesMenu.entityKind === "DataWriter" || entitiesMenu.entityKind === "DataReader", "entity_option": endpointsOption})
-        entityModel.append({"available": true, "entity_option": changeAlias})
-        entityModel.append({"available": true, "entity_option": viewProblems})
+        entityModel.append({"available": entitiesMenu.entityKind === "DataWriter" || entitiesMenu.entityKind === "DataReader", "option": showGraph})
+        entityModel.append({"available": true, "option": changeAlias})
+        entityModel.append({"available": true, "option": viewProblems})
     }
 }

--- a/qml/EntityList.qml
+++ b/qml/EntityList.qml
@@ -90,7 +90,7 @@ Rectangle {
                         }
                         onClicked: {
                             if(mouse.button & Qt.RightButton) {
-                                openEntitiesMenu("", id, name, kind)
+                                openEntitiesMenu(controller.get_domain_id(id), id, name, kind, openMenuCaller.leftPanel)
                             } else  {
                                 controller.participant_click(id)
                             }
@@ -173,7 +173,7 @@ Rectangle {
                                     }
                                     onClicked: {
                                         if(mouse.button & Qt.RightButton) {
-                                            openEntitiesMenu("", id, name, kind)
+                                            openEntitiesMenu(controller.get_domain_id(id), id, name, kind, openMenuCaller.leftPanel)
                                         } else {
                                             controller.endpoint_click(id)
                                         }
@@ -245,7 +245,7 @@ Rectangle {
 
                                                 onClicked: {
                                                     if(mouse.button & Qt.RightButton) {
-                                                        openEntitiesMenu("", id, name, kind)
+                                                        openEntitiesMenu(controller.get_domain_id(id), id, name, kind, openMenuCaller.leftPanel)
                                                     } else {
                                                         controller.locator_click(id)
                                                     }

--- a/qml/LeftPanel.qml
+++ b/qml/LeftPanel.qml
@@ -32,6 +32,11 @@ RowLayout {
         Issues
     }
 
+    readonly property var openTopicMenuCaller: ({
+        logicalPanel: 0,
+        domainGraph: 1
+    })
+
     property variant panelItem: [monitoringPanel, statusPanel, issuesPanel]
 
     property variant visiblePanel: panelItem[LeftPanel.LeftSubPanel.Explorer]
@@ -95,12 +100,20 @@ RowLayout {
         entitiesMenu.popup()
     }
 
-    function openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind) {
+    function openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind, caller) {
         topicMenu.domainEntityId = domainEntityId
         topicMenu.domainId = domainId
         topicMenu.entityId = entityId
         topicMenu.currentAlias = currentAlias
         topicMenu.entityKind = entityKind
+
+        if (caller === openTopicMenuCaller.logicalPanel) {
+            topicMenu.showGraphButtonName = "Show topic graph"
+        }
+        else {
+            topicMenu.showGraphButtonName = "Filter topic graph"
+        }
+
         topicMenu.popup()
     }
 

--- a/qml/LeftPanel.qml
+++ b/qml/LeftPanel.qml
@@ -32,8 +32,9 @@ RowLayout {
         Issues
     }
 
-    readonly property var openTopicMenuCaller: ({
-        logicalPanel: 0,
+    // Enum exposed in Panels.qml for Menu items message customization
+    readonly property var openMenuCaller: ({
+        leftPanel: 0,
         domainGraph: 1
     })
 
@@ -72,7 +73,10 @@ RowLayout {
 
     EntitiesMenu {
         id: entitiesMenu
-    }
+        onChangeAlias: leftPanel.changeAlias(domainEntityId, entityId, currentAlias, entityKind)
+        onFilterEntityStatusLog: leftPanel.filterEntityStatusLog(entityId)
+        onOpenTopicView: leftPanel.openTopicView(domainEntityId, domainId, topicId)
+        }
 
     TopicMenu {
         id: topicMenu
@@ -92,11 +96,19 @@ RowLayout {
         aliasDialog.open()
     }
 
-    function openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind) {
+    function openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind, caller) {
         entitiesMenu.domainEntityId = domainEntityId
         entitiesMenu.entityId = entityId
         entitiesMenu.currentAlias = currentAlias
         entitiesMenu.entityKind = entityKind
+
+        if (caller === openMenuCaller.domainGraph) {
+            entitiesMenu.showGraphButtonName = "Filter topic graph"
+        }
+        else {
+            entitiesMenu.showGraphButtonName = "Show topic graph"
+        }
+
         entitiesMenu.popup()
     }
 
@@ -107,11 +119,11 @@ RowLayout {
         topicMenu.currentAlias = currentAlias
         topicMenu.entityKind = entityKind
 
-        if (caller === openTopicMenuCaller.logicalPanel) {
-            topicMenu.showGraphButtonName = "Show topic graph"
+        if (caller === openMenuCaller.domainGraph) {
+            topicMenu.showGraphButtonName = "Filter topic graph"
         }
         else {
-            topicMenu.showGraphButtonName = "Filter topic graph"
+            topicMenu.showGraphButtonName = "Show topic graph"
         }
 
         topicMenu.popup()

--- a/qml/LogicalView.qml
+++ b/qml/LogicalView.qml
@@ -97,7 +97,7 @@ Rectangle {
                         }
                         onClicked: {
                             if(mouse.button & Qt.RightButton) {
-                                openEntitiesMenu(domainId, id, name, kind)
+                                openEntitiesMenu(domainId, id, name, kind, openMenuCaller.leftPanel)
                             } else {
                                 controller.domain_click(id)
                             }
@@ -167,7 +167,7 @@ Rectangle {
 
                                     onClicked: {
                                         if(mouse.button & Qt.RightButton) {
-                                            openTopicMenu(domainId, domainName, id, name, kind, openTopicMenuCaller.logicalPanel)
+                                            openTopicMenu(domainId, domainName, id, name, kind, openMenuCaller.leftPanel)
                                         } else {
                                             controller.topic_click(id)
                                         }

--- a/qml/LogicalView.qml
+++ b/qml/LogicalView.qml
@@ -167,7 +167,7 @@ Rectangle {
 
                                     onClicked: {
                                         if(mouse.button & Qt.RightButton) {
-                                            openTopicMenu(domainId, domainName, id, name, kind)
+                                            openTopicMenu(domainId, domainName, id, name, kind, openTopicMenuCaller.logicalPanel)
                                         } else {
                                             controller.topic_click(id)
                                         }

--- a/qml/Panels.qml
+++ b/qml/Panels.qml
@@ -136,7 +136,7 @@ RowLayout {
                         panels.openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind)
                     }
                     onOpenTopicMenu: {
-                        panels.openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind)
+                        panels.openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind, caller)
                     }
                 }
                 StatusLayout {
@@ -163,6 +163,9 @@ RowLayout {
             }
         }
     }
+
+    // Expose LeftPanel openTopicMenuCaller enum to be used in other children components (e.g: DomainGraphView.qml)
+    property alias openTopicMenuCaller: leftPanel.openTopicMenuCaller
 
     function createHistoricChart(dataKind){
         tabs.chartsLayout_createHistoricChart(dataKind)
@@ -200,7 +203,7 @@ RowLayout {
         leftPanel.openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind)
     }
 
-    function openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind) {
-        leftPanel.openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind)
+    function openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind, caller) {
+        leftPanel.openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind, caller)
     }
 }

--- a/qml/Panels.qml
+++ b/qml/Panels.qml
@@ -133,7 +133,7 @@ RowLayout {
                         }
                     }
                     onOpenEntitiesMenu: {
-                        panels.openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind)
+                        panels.openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind, caller)
                     }
                     onOpenTopicMenu: {
                         panels.openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind, caller)
@@ -164,8 +164,8 @@ RowLayout {
         }
     }
 
-    // Expose LeftPanel openTopicMenuCaller enum to be used in other children components (e.g: DomainGraphView.qml)
-    property alias openTopicMenuCaller: leftPanel.openTopicMenuCaller
+    // Expose LeftPanel openMenuCaller enum to be used in other children components (e.g: DomainGraphView.qml)
+    property alias openMenuCaller: leftPanel.openMenuCaller
 
     function createHistoricChart(dataKind){
         tabs.chartsLayout_createHistoricChart(dataKind)
@@ -199,8 +199,8 @@ RowLayout {
         leftPanel.changeExplorerEntityInfo(status)
     }
 
-    function openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind) {
-        leftPanel.openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind)
+    function openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind, caller) {
+        leftPanel.openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind, caller)
     }
 
     function openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind, caller) {

--- a/qml/PhysicalView.qml
+++ b/qml/PhysicalView.qml
@@ -90,7 +90,7 @@ Rectangle {
                         }
                         onClicked: {
                             if(mouse.button & Qt.RightButton) {
-                                openEntitiesMenu("", id, name, kind)
+                                openEntitiesMenu("", id, name, kind, openMenuCaller.leftPanel)
                             } else {
                                 controller.host_click(id)
                             }
@@ -174,7 +174,7 @@ Rectangle {
                                     }
                                     onClicked: {
                                         if(mouse.button & Qt.RightButton) {
-                                            openEntitiesMenu("", id, name, kind)
+                                            openEntitiesMenu("", id, name, kind, openMenuCaller.leftPanel)
                                         } else {
                                             controller.user_click(id)
                                         }
@@ -246,7 +246,7 @@ Rectangle {
 
                                                 onClicked: {
                                                     if(mouse.button & Qt.RightButton) {
-                                                        openEntitiesMenu("", id, name, kind)
+                                                        openEntitiesMenu("", id, name, kind, openMenuCaller.leftPanel)
                                                     } else {
                                                         controller.process_click(id)
                                                     }

--- a/qml/TabLayout.qml
+++ b/qml/TabLayout.qml
@@ -28,7 +28,7 @@ Item {
     property bool fullScreen: false                                         // ChartsLayout inherited var
 
     // Public signals
-    signal openEntitiesMenu(string domainEntityId, string entityId, string currentAlias, string entityKind)
+    signal openEntitiesMenu(string domainEntityId, string entityId, string currentAlias, string entityKind, int caller)
     signal openTopicMenu(string domainEntityId, string domainId, string entityId, string currentAlias, string entityKind, int caller)
 
     // Private properties
@@ -253,7 +253,7 @@ Item {
                         }
 
                         onOpenEntitiesMenu: {
-                            tabLayout.openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind)
+                            tabLayout.openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind, caller)
                         }
                         onOpenTopicMenu: {
                             tabLayout.openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind, caller)

--- a/qml/TabLayout.qml
+++ b/qml/TabLayout.qml
@@ -29,7 +29,7 @@ Item {
 
     // Public signals
     signal openEntitiesMenu(string domainEntityId, string entityId, string currentAlias, string entityKind)
-    signal openTopicMenu(string domainEntityId, string domainId, string entityId, string currentAlias, string entityKind)
+    signal openTopicMenu(string domainEntityId, string domainId, string entityId, string currentAlias, string entityKind, int caller)
 
     // Private properties
     property int current_: 0                                                // current tab displayed
@@ -256,7 +256,7 @@ Item {
                             tabLayout.openEntitiesMenu(domainEntityId, entityId, currentAlias, entityKind)
                         }
                         onOpenTopicMenu: {
-                            tabLayout.openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind)
+                            tabLayout.openTopicMenu(domainEntityId, domainId, entityId, currentAlias, entityKind, caller)
                         }
 
                         onOpenLoadingGraphDialog: {

--- a/qml/TopicMenu.qml
+++ b/qml/TopicMenu.qml
@@ -29,6 +29,7 @@ Menu {
     property string entityId: ""
     property string currentAlias: ""
     property string entityKind: ""
+    property string showGraphButtonName: ""
 
     MenuItem {
         text: "Change alias"
@@ -39,7 +40,7 @@ Menu {
         onTriggered: filterEntityStatusLog(menu.entityId)
     }
     MenuItem {
-        text: "Filter graph view"
+        text: menu.showGraphButtonName
         onTriggered: openTopicView(menu.domainEntityId, menu.domainId, menu.entityId)
     }
     MenuItem {

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -329,6 +329,24 @@ QString Controller::get_type_idl(
     return utils::to_QString(engine_->get_type_idl(backend::models_id_to_backend_id(entity_id)));
 }
 
+QString Controller::get_endpoint_topic_id(
+        QString endpoint_id)
+{
+    return engine_->get_endpoint_topic_id(endpoint_id);
+}
+
+QString Controller::get_domain_id(
+        QString entity_id)
+{
+    return engine_->get_domain_id(entity_id);
+}
+
+QString Controller::get_name(
+        QString entity_id)
+{
+    return utils::to_QString(engine_->get_name(backend::models_id_to_backend_id(entity_id)));
+}
+
 QString Controller::get_data_type_name(
         QString entity_id)
 {

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1730,7 +1730,8 @@ std::string Engine::get_type_idl(
 models::EntityId Engine::get_endpoint_topic_id(
         const models::EntityId& endpoint_id)
 {
-    backend::EntityId topic_id = backend_connection_.get_endpoint_topic_id(backend::models_id_to_backend_id(endpoint_id));
+    backend::EntityId topic_id =
+            backend_connection_.get_endpoint_topic_id(backend::models_id_to_backend_id(endpoint_id));
     return backend::backend_id_to_models_id(topic_id);
 }
 
@@ -1739,7 +1740,7 @@ models::EntityId Engine::get_domain_id(
 {
     backend::EntityId domain_id = backend_connection_.get_domain_id(backend::models_id_to_backend_id(entity_id));
     return backend::backend_id_to_models_id(domain_id);
-}   
+}
 
 bool Engine::data_kind_has_target(
         const QString& data_kind)

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1709,6 +1709,12 @@ std::vector<std::string> Engine::get_data_kinds()
     return backend_connection_.get_data_kinds();
 }
 
+std::string Engine::get_name(
+        const backend::EntityId& entity_id)
+{
+    return backend_connection_.get_name(entity_id);
+}
+
 std::string Engine::get_data_type_name(
         const backend::EntityId& entity_id)
 {
@@ -1720,6 +1726,20 @@ std::string Engine::get_type_idl(
 {
     return backend_connection_.get_type_idl(entity_id);
 }
+
+models::EntityId Engine::get_endpoint_topic_id(
+        const models::EntityId& endpoint_id)
+{
+    backend::EntityId topic_id = backend_connection_.get_endpoint_topic_id(backend::models_id_to_backend_id(endpoint_id));
+    return backend::backend_id_to_models_id(topic_id);
+}
+
+models::EntityId Engine::get_domain_id(
+        const models::EntityId& entity_id)
+{
+    backend::EntityId domain_id = backend_connection_.get_domain_id(backend::models_id_to_backend_id(entity_id));
+    return backend::backend_id_to_models_id(domain_id);
+}   
 
 bool Engine::data_kind_has_target(
         const QString& data_kind)

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -495,6 +495,18 @@ EntityInfo SyncBackendConnection::get_info(
     }
 }
 
+backend::EntityId SyncBackendConnection::get_endpoint_topic_id(
+        backend::EntityId endpoint_id)
+{
+    return StatisticsBackend::get_endpoint_topic_id(endpoint_id);
+}
+
+backend::EntityId SyncBackendConnection::get_domain_id(
+        backend::EntityId entity_id)
+{
+    return StatisticsBackend::get_domain_id(entity_id);
+}
+
 bool SyncBackendConnection::get_alive(
         EntityId id)
 {


### PR DESCRIPTION
# Main Changes

- Fixed a compilation error in docs due to a invalid reference
- Added new EntityId getters
- Added an "open menu" calls tracker to allow customizing menu item messages for each monitor panel
- Refactored EntitiesMenu component to load items dynamically, allowing different options for each entity kind

This PR must be merged after:
- https://github.com/eProsima/Fast-DDS-statistics-backend/pull/254