### PR TITLE
[21818] Improve topic view

### DIFF
--- a/imports/Theme/Theme.qml
+++ b/imports/Theme/Theme.qml
@@ -10,6 +10,7 @@ QtObject {
     readonly property color eProsimaYellow: "#ffc001"
 
     readonly property color grey: "#808080"
+    readonly property color midGrey: "#585858"
     readonly property color lightGrey: "#d3d3d3"
     readonly property color darkGrey: "#3e3e3e"
     readonly property color x11Grey: "#BEBEBE"

--- a/qml.qrc
+++ b/qml.qrc
@@ -236,10 +236,12 @@
         <file alias="left_arrow_black.svg">resources/images/icons/left_arrow/left_arrow_black.svg</file>
         <file alias="left_arrow_eProsimaLightBlue.svg">resources/images/icons/left_arrow/left_arrow_eProsimaLightBlue.svg</file>
         <file alias="left_arrow_grey.svg">resources/images/icons/left_arrow/left_arrow_grey.svg</file>
+        <file alias="left_arrow_mid_grey.svg">resources/images/icons/left_arrow/left_arrow_mid_grey.svg</file>
         <file alias="left_arrow_white.svg">resources/images/icons/left_arrow/left_arrow_white.svg</file>
         <file alias="right_arrow_black.svg">resources/images/icons/right_arrow/right_arrow_black.svg</file>
         <file alias="right_arrow_eProsimaLightBlue.svg">resources/images/icons/right_arrow/right_arrow_eProsimaLightBlue.svg</file>
         <file alias="right_arrow_grey.svg">resources/images/icons/right_arrow/right_arrow_grey.svg</file>
+        <file alias="right_arrow_mid_grey.svg">resources/images/icons/right_arrow/right_arrow_mid_grey.svg</file>
         <file alias="right_arrow_white.svg">resources/images/icons/right_arrow/right_arrow_white.svg</file>
         <file alias="rounded_left_arrow_black.svg">resources/images/icons/rounded_left_arrow/rounded_left_arrow_black.svg</file>
         <file alias="rounded_left_arrow_eProsimaLightBlue.svg">resources/images/icons/rounded_left_arrow/rounded_left_arrow_eProsimaLightBlue.svg</file>

--- a/qml/DomainGraphLayout.qml
+++ b/qml/DomainGraphLayout.qml
@@ -40,6 +40,7 @@ Item
 
     // Private properties
     property var topic_locations_: {}                   // topic information needed for connection representation
+    property var topic_color_map_: {}                   // map with boolean values to alternate colors in tags and connections
     property var endpoint_topic_connections_: {}        // endpoint information needed for connection representation
     property var topic_painted_: []                     // already painted topic connection references
     property var endpoint_painted_: []                  // already painted endpoint connection references
@@ -82,6 +83,7 @@ Item
     readonly property int timer_initial_ms_interval_: 200
     readonly property int hover_text_offset_: 50
     readonly property string topic_color_: Theme.grey
+    readonly property string topic_color2_: Theme.darkGrey
     readonly property string host_color_: Theme.darkGrey
     readonly property string user_color_: Theme.eProsimaLightBlue
     readonly property string process_color_: Theme.eProsimaDarkBlue
@@ -201,6 +203,7 @@ Item
                         "id": topicsList.currentItem.topic_id,
                         "width" : draw_width + topicsList.currentItem.width/2
                     }
+                    topic_color_map_[topicsList.currentItem.topic_id] = topicsList.currentItem.even_position
                     draw_width += topicsList.currentItem.width + elements_spacing_
                 }
 
@@ -212,6 +215,7 @@ Item
             delegate: Rectangle
             {
                 property string topic_id: modelData["id"]
+                property bool even_position: index % 2 === 0
                 implicitWidth: topic_tag.implicitWidth
                 height: topicsList.height
                 color: "transparent"
@@ -222,7 +226,7 @@ Item
                     id: topic_tag
                     implicitWidth: topic_tag_size_
                     height: label_height_
-                    color: topic_color_
+                    color: parent.even_position ? topic_color_ : topic_color2_
                     radius: radius_
 
                     RowLayout {
@@ -278,7 +282,7 @@ Item
                     anchors.bottom: parent.bottom
                     anchors.horizontalCenter: topic_tag.horizontalCenter
                     width: topic_thickness_
-                    color: topic_color_
+                    color: parent.even_position ? topic_color_ : topic_color2_
                 }
 
                 Connections {
@@ -378,7 +382,7 @@ Item
                             ,"y": endpoint_topic_connections_[key]["y"] - (connection_thickness_ / 2)
                             ,"width": topic_locations_[topic_id]["width"]
                             ,"height":connection_thickness_, "z":200, "left_margin": 2*elements_spacing_
-                            ,"arrow_color": topic_color_, "background_color": background_color.color
+                            ,"arrow_color": topic_color_map_[topic_id] ? topic_color_ : topic_color2_, "background_color": background_color.color
                             ,"endpoint_id": key }
                         var connection_bar = arrow_component.createObject(topic_connections, input)
                         topic_painted_[topic_painted_.length] = key;
@@ -1331,7 +1335,7 @@ Item
                                 ,"left_direction": endpoint_topic_connections_[key]["left_direction"]
                                 ,"width": 5*elements_spacing_
                                 ,"height":connection_thickness_, "z":200
-                                ,"arrow_color": topic_color_, "background_color": background_color.color
+                                ,"arrow_color": topic_color_map_[topic_id] ? topic_color_ : topic_color2_, "background_color": background_color.color
                                 ,"endpoint_id": key }
                             var connection_bar = arrow_component.createObject(mainSpace, input)
                             endpoint_painted_[endpoint_painted_.length] = key
@@ -1699,6 +1703,7 @@ Item
     function clear_graph()
     {
         topic_locations_ = {}
+        topic_color_map_ = {}
         endpoint_topic_connections_ = {}
         endpoint_painted_ = []
         topic_painted_ = []

--- a/qml/DomainGraphLayout.qml
+++ b/qml/DomainGraphLayout.qml
@@ -69,6 +69,7 @@ Item
     readonly property int elements_spacing_: 5
     readonly property int containers_spacing_: 100
     readonly property int topic_tag_size_: 150
+    readonly property int topic_tag_margin_: 30
     readonly property int max_topic_name_size_: 100
     readonly property int endpoint_height_: 30
     readonly property int first_indentation_: 5
@@ -230,12 +231,12 @@ Item
                 Rectangle
                 {
                     id: topic_tag
-                    implicitWidth: topic_tag_size_
                     height: label_height_
                     color: parent.even_position ? topic_color_ : topic_color2_
                     radius: radius_
                     y: !parent.even_position ? topicsList.yOffset : 0
                     property int textFullWidth: text_metrics.width
+                    implicitWidth: topicsList.count > 1 ? topic_tag_size_ : Math.max(topic_tag_label.width + topic_tag_margin_, topic_tag_size_)
 
                     Label {
                         id: topic_tag_label
@@ -243,7 +244,7 @@ Item
                         text: modelData["alias"]
                         Layout.rightMargin: 2* first_indentation_
                         color: "white"
-                        width: max_topic_name_size_
+                        width: topicsList.count > 1 ? max_topic_name_size_ : text.width
                         horizontalAlignment: Text.AlignHCenter
                         elide: Text.ElideRight
                     }

--- a/qml/DomainGraphLayout.qml
+++ b/qml/DomainGraphLayout.qml
@@ -83,6 +83,7 @@ Item
     readonly property int wheel_displacement_: 30
     readonly property int timer_initial_ms_interval_: 200
     readonly property int hover_text_offset_: 50
+    readonly property int hover_delay_: 250
     readonly property string topic_color_: Theme.grey
     readonly property string topic_color_alias_: "grey" // color alias for svg icons
     readonly property string topic_color2_: Theme.midGrey
@@ -281,6 +282,7 @@ Item
                         ToolTip.text: modelData["alias"]
                         // Show hover only if text is elided
                         ToolTip.visible: topic_tag_mouse_area.containsMouse && text_metrics.width > topic_tag.width
+                        ToolTip.delay: hover_delay_
                     }
                 }
 

--- a/qml/DomainGraphLayout.qml
+++ b/qml/DomainGraphLayout.qml
@@ -84,7 +84,9 @@ Item
     readonly property int timer_initial_ms_interval_: 200
     readonly property int hover_text_offset_: 50
     readonly property string topic_color_: Theme.grey
+    readonly property string topic_color_alias_: "grey" // color alias for svg icons
     readonly property string topic_color2_: Theme.midGrey
+    readonly property string topic_color2_alias_: "mid_grey" // color alias for svg icons
     readonly property string host_color_: Theme.darkGrey
     readonly property string user_color_: Theme.eProsimaLightBlue
     readonly property string process_color_: Theme.eProsimaDarkBlue
@@ -390,7 +392,9 @@ Item
                             ,"y": endpoint_topic_connections_[key]["y"] - (connection_thickness_ / 2)
                             ,"width": topic_locations_[topic_id]["width"]
                             ,"height":connection_thickness_, "z":200, "left_margin": 2*elements_spacing_
-                            ,"arrow_color": topic_style_map_[topic_id] ? topic_color_ : topic_color2_, "background_color": background_color.color
+                            ,"arrow_color": topic_style_map_[topic_id] ? topic_color_ : topic_color2_
+                            ,"arrow_head_color": topic_style_map_[topic_id] ? "grey" : "mid_grey"
+                            , "background_color": background_color.color
                             ,"endpoint_id": key }
                         var connection_bar = arrow_component.createObject(topic_connections, input)
                         topic_painted_[topic_painted_.length] = key;
@@ -1344,6 +1348,7 @@ Item
                                 ,"width": 5*elements_spacing_
                                 ,"height":connection_thickness_, "z":200
                                 ,"arrow_color": topic_style_map_[topic_id] ? topic_color_ : topic_color2_, "background_color": background_color.color
+                                ,"arrow_head_color": topic_style_map_[topic_id] ? topic_color_alias_ : topic_color2_alias_
                                 ,"endpoint_id": key }
                             var connection_bar = arrow_component.createObject(mainSpace, input)
                             endpoint_painted_[endpoint_painted_.length] = key

--- a/qml/DomainGraphLayout.qml
+++ b/qml/DomainGraphLayout.qml
@@ -67,6 +67,8 @@ Item
     readonly property int connection_thickness_: 6
     readonly property int elements_spacing_: 5
     readonly property int containers_spacing_: 100
+    readonly property int topic_tag_size_: 150
+    readonly property int max_topic_name_size_: 50
     readonly property int endpoint_height_: 30
     readonly property int first_indentation_: 5
     readonly property int icon_size_: 18
@@ -78,6 +80,7 @@ Item
     readonly property int topic_thickness_: 10
     readonly property int wheel_displacement_: 30
     readonly property int timer_initial_ms_interval_: 200
+    readonly property int hover_text_offset_: 50
     readonly property string topic_color_: Theme.grey
     readonly property string host_color_: Theme.darkGrey
     readonly property string user_color_: Theme.eProsimaLightBlue
@@ -217,7 +220,7 @@ Item
                 Rectangle
                 {
                     id: topic_tag
-                    implicitWidth: topicRowLayout.implicitWidth
+                    implicitWidth: topic_tag_size_
                     height: label_height_
                     color: topic_color_
                     radius: radius_
@@ -237,12 +240,16 @@ Item
                             text: modelData["alias"]
                             Layout.rightMargin: 2* first_indentation_
                             color: "white"
+                            Layout.preferredWidth: max_topic_name_size_
+                            elide: Text.ElideRight
                         }
                     }
                     MouseArea
                     {
+                        id: topic_tag_mouse_area
                         anchors.fill: parent
                         acceptedButtons: Qt.LeftButton | Qt.RightButton
+                        hoverEnabled: true
                         onClicked:
                         {
                             if(mouse.button & Qt.RightButton) {
@@ -251,6 +258,15 @@ Item
                                 controller.topic_click(modelData["id"])
                             }
                         }
+                    }
+                    Label {
+                        id: hover_label
+                        visible: false
+                        anchors.top: parent.bottom
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.topMargin: hover_text_offset_
+                        ToolTip.text: modelData["alias"]
+                        ToolTip.visible: topic_tag_mouse_area.containsMouse
                     }
                 }
 

--- a/qml/GraphConnection.qml
+++ b/qml/GraphConnection.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.0
-import QtGraphicalEffects 1.15
 
 Item {
     id: graphConnection
@@ -8,6 +7,7 @@ Item {
     property bool right_direction: false                // defines if the represented connection must draw a right arrow
     property int left_margin: 0                         // left margin to be applied
     property string arrow_color: Theme.grey             // connection color
+    property string arrow_head_color: "grey"
     property string background_color: "white"           // background color
     property string endpoint_id: ""                     // graph refferred entity id
     property bool hidden_arrow: false                   // associated topic is not visible
@@ -83,15 +83,8 @@ Item {
 
         IconSVG {
             name: "left_arrow"
-            color: "grey"
+            color: arrow_head_color
             size: arrow_size_
-        }
-
-        // Change left arrow icon color to fit base_arrow color
-        ColorOverlay {
-            anchors.fill: left_arrow
-            source: left_arrow
-            color: arrow_color
         }
     }
 
@@ -167,15 +160,8 @@ Item {
 
         IconSVG {
             name: "right_arrow"
-            color: "grey"
+            color: arrow_head_color
             size: arrow_size_ + right_arrow_margin_
-        }
-
-        // Change right arrow icon color to fit base_arrow color
-        ColorOverlay {
-            anchors.fill: right_arrow
-            source: right_arrow
-            color: arrow_color
         }
     }
 

--- a/qml/GraphConnection.qml
+++ b/qml/GraphConnection.qml
@@ -82,7 +82,6 @@ Item {
         anchors.left: parent.left; anchors.leftMargin: left_arrow_margin_
 
         IconSVG {
-            id: left_arrow_icon
             name: "left_arrow"
             color: "grey"
             size: arrow_size_
@@ -90,8 +89,8 @@ Item {
 
         // Change left arrow icon color to fit base_arrow color
         ColorOverlay {
-            anchors.fill: left_arrow_icon
-            source: left_arrow_icon
+            anchors.fill: left_arrow
+            source: left_arrow
             color: arrow_color
         }
     }

--- a/qml/GraphConnection.qml
+++ b/qml/GraphConnection.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.0
+import QtGraphicalEffects 1.15
 
 Item {
     id: graphConnection
@@ -81,9 +82,17 @@ Item {
         anchors.left: parent.left; anchors.leftMargin: left_arrow_margin_
 
         IconSVG {
+            id: left_arrow_icon
             name: "left_arrow"
             color: "grey"
             size: arrow_size_
+        }
+
+        // Change left arrow icon color to fit base_arrow color
+        ColorOverlay {
+            anchors.fill: left_arrow_icon
+            source: left_arrow_icon
+            color: arrow_color
         }
     }
 
@@ -161,6 +170,13 @@ Item {
             name: "right_arrow"
             color: "grey"
             size: arrow_size_ + right_arrow_margin_
+        }
+
+        // Change right arrow icon color to fit base_arrow color
+        ColorOverlay {
+            anchors.fill: right_arrow
+            source: right_arrow
+            color: arrow_color
         }
     }
 

--- a/resources/images/icons/left_arrow/left_arrow_mid_grey.svg
+++ b/resources/images/icons/left_arrow/left_arrow_mid_grey.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#000000" style=""><rect id="backgroundrect" width="100%" height="100%" x="0" y="0" fill="none" stroke="none"/>
+
+ <g style="" class="currentLayer">
+  <title>Layer 1</title>
+  <path transform="rotate(-90 12 12)" id="svg_1" d="m21,21l-18,0l9,-18l9,18z" class="selected" fill="#585858" fill-opacity="1"/>
+ </g>
+</svg>

--- a/resources/images/icons/right_arrow/right_arrow_mid_grey.svg
+++ b/resources/images/icons/right_arrow/right_arrow_mid_grey.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="#000000" style=""><rect id="backgroundrect" width="100%" height="100%" x="0" y="0" fill="none" stroke="none"/>
+
+ <g style="" class="currentLayer">
+  <title>Layer 1</title>
+  <path transform="rotate(90 9,9.000000000000002) " id="svg_1" d="m18,18 l-18,0 l9,-18 l9,18 z" class="selected" fill="#585858" fill-opacity="1"/>
+ </g>
+</svg>


### PR DESCRIPTION
# Main changes
- DomainGraph shows more compact, intercalating topic tags
- Added intercalated colors for Topic tags, topic bars and connection arrows .
- Fixed tag size. Larger tag names are elided and a hover shows the complete name

This PR must be merged after:
- https://github.com/eProsima/Fast-DDS-monitor/pull/238
