### PR TITLE
[22066] Improve QoS incompatibility representation 

### DIFF
--- a/include/fastdds_monitor/Controller.h
+++ b/include/fastdds_monitor/Controller.h
@@ -66,6 +66,9 @@ public:
     {
         std::map<backend::EntityId, uint32_t> errors;
         std::map<backend::EntityId, uint32_t> warnings;
+        // Represents the subset of errors that a entity shares with other entities, and are deleted when the entity becomes inactive
+        // Fist key is the entity id, second key is the remote entity guid and value is the number of errors shared
+        std::map<backend::EntityId, std::map<std::string, uint32_t>> shared_errors;
         int32_t total_errors = 0;
         int32_t total_warnings = 0;
     }

--- a/include/fastdds_monitor/backend/SyncBackendConnection.h
+++ b/include/fastdds_monitor/backend/SyncBackendConnection.h
@@ -132,6 +132,10 @@ public:
     std::string get_data_type_name(
             backend::EntityId id);
 
+    //! Get the guid associated to a given entity from the Backend by calling \c get_info
+    std::string get_guid(
+            backend::EntityId id);
+
     //! Get the status level of an entity from the Backend by calling \c get_status
     StatusLevel get_status(
             backend::EntityId id);
@@ -198,6 +202,14 @@ public:
     bool get_status_data(
             EntityId source_entity_id,
             SampleLostSample& sample);
+
+    bool get_status_data(
+            EntityId source_entity_id,
+            ExtendedIncompatibleQosSample& sample);
+
+    //! Convert a given entity guid to string format 
+    std::string get_deserialized_guid(
+            const backend::GUID_s& data);
 
     //! Get info from an entity from the Backend
     std::vector<EntityId> get_entities(

--- a/include/fastdds_monitor/backend/SyncBackendConnection.h
+++ b/include/fastdds_monitor/backend/SyncBackendConnection.h
@@ -207,7 +207,7 @@ public:
             EntityId source_entity_id,
             ExtendedIncompatibleQosSample& sample);
 
-    //! Convert a given entity guid to string format 
+    //! Convert a given entity guid to string format
     std::string get_deserialized_guid(
             const backend::GUID_s& data);
 

--- a/include/fastdds_monitor/backend/backend_types.h
+++ b/include/fastdds_monitor/backend/backend_types.h
@@ -28,6 +28,7 @@
 #include <fastdds_statistics_backend/types/app_names.h>
 #include <fastdds_statistics_backend/types/JSONTags.h>
 #include <fastdds_statistics_backend/types/types.hpp>
+#include <fastdds_statistics_backend/topic_types/types.hpp>
 
 namespace backend {
 
@@ -40,6 +41,7 @@ using StatusLevel = eprosima::statistics_backend::StatusLevel;
 using StatisticKind = eprosima::statistics_backend::StatisticKind;
 using EntityInfo = eprosima::statistics_backend::Info;
 using Timestamp = eprosima::statistics_backend::Timestamp;
+using GUID_s = eprosima::fastdds::statistics::detail::GUID_s;
 
 // Status types from backend
 using ConnectionListSample = eprosima::statistics_backend::ConnectionListSample;
@@ -50,6 +52,8 @@ using LivelinessChangedSample = eprosima::statistics_backend::LivelinessChangedS
 using LivelinessLostSample = eprosima::statistics_backend::LivelinessLostSample;
 using ProxySample = eprosima::statistics_backend::ProxySample;
 using SampleLostSample = eprosima::statistics_backend::SampleLostSample;
+using ExtendedIncompatibleQoSStatusSeq = eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s;
+using ExtendedIncompatibleQoSStatus = eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s;
 //using StatusesSizeSample = eprosima::statistics_backend::StatusesSizeSample;
 
 //! Reference the ID_ALL in the project

--- a/include/fastdds_monitor/backend/backend_utils.h
+++ b/include/fastdds_monitor/backend/backend_utils.h
@@ -124,6 +124,9 @@ std::string entity_status_description(
 std::string policy_documentation_description(
         const uint32_t& id);
 
+std::string guid_s_to_string(
+        const backend::GUID_s& guid);
+        
 } //namespace backend
 
 #endif // _EPROSIMA_FASTDDS_MONITOR_BACKEND_BACKENDUTILS_H

--- a/include/fastdds_monitor/backend/backend_utils.h
+++ b/include/fastdds_monitor/backend/backend_utils.h
@@ -126,7 +126,7 @@ std::string policy_documentation_description(
 
 std::string guid_s_to_string(
         const backend::GUID_s& guid);
-        
+
 } //namespace backend
 
 #endif // _EPROSIMA_FASTDDS_MONITOR_BACKEND_BACKENDUTILS_H

--- a/include/fastdds_monitor/model/tree/StatusTreeItem.h
+++ b/include/fastdds_monitor/model/tree/StatusTreeItem.h
@@ -206,21 +206,23 @@ private:
     QVariant description_variant_;
     QVariant is_active_variant_;
 
-///////////////////////
-// Signals and slots //
-///////////////////////
+    ///////////////////////
+    // Signals and slots //
+    ///////////////////////
 
 public slots:
+
     void onItemRemoved(
             std::string guid);
-                    
+
 signals:
+
     // Notify when the node is removed from the tree
     // NOTE: Currently, the signal is only used to communicate item changes between top-level items and leaf items to update the Tree View when an endpoint becomes inactive.
     // Signal-slot connections between different types of nodes could lead to unexpected behaviors.
     void itemRemoved(
             std::string guid);
-    
+
 };
 
 } // namespace models

--- a/include/fastdds_monitor/model/tree/StatusTreeModel.h
+++ b/include/fastdds_monitor/model/tree/StatusTreeModel.h
@@ -175,10 +175,14 @@ public:
             const backend::EntityId& id,
             const std::string& data,
             const backend::StatusLevel& status,
-            const std::string& description);
+            const std::string& description,
+            const std::string& guid);
 
     void set_source_model(
             StatusTreeModel* source_model);
+
+    //! Disconnect every item connected to a StatusTreeModel signal
+    void disconnect_all_item_signals();
 
     /*!
      *  Filters the model if it is defined as proxy
@@ -205,6 +209,20 @@ private:
     bool is_empty_;
 
     backend::EntityId current_filter_;
+
+///////////////////////
+// Signals and Slots //
+///////////////////////
+
+public slots:
+    void onItemRemoved(
+            std::string guid);
+signals:
+    // Notify when the node is removed from the tree
+    // NOTE: Currently, the signal is only used to communicate item changes between top-level items and leaf items to update the Status Tree View when an endpoint becomes inactive.
+    // Signal-slot connections between different types of nodes could lead to unexpected behaviors.
+    void itemRemoved(
+            std::string guid);
 };
 
 } // namespace models

--- a/include/fastdds_monitor/model/tree/StatusTreeModel.h
+++ b/include/fastdds_monitor/model/tree/StatusTreeModel.h
@@ -210,14 +210,17 @@ private:
 
     backend::EntityId current_filter_;
 
-///////////////////////
-// Signals and Slots //
-///////////////////////
+    ///////////////////////
+    // Signals and Slots //
+    ///////////////////////
 
 public slots:
+
     void onItemRemoved(
             std::string guid);
+
 signals:
+
     // Notify when the node is removed from the tree
     // NOTE: Currently, the signal is only used to communicate item changes between top-level items and leaf items to update the Status Tree View when an endpoint becomes inactive.
     // Signal-slot connections between different types of nodes could lead to unexpected behaviors.

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -18,6 +18,8 @@
 #include <chrono>
 #include <sstream>
 
+#include <set>
+
 #include <QDateTime>
 #include <QDebug>
 #include <QQmlApplicationEngine>
@@ -1009,13 +1011,14 @@ bool Engine::update_entity_status(
     if (id == backend::ID_ALL)
     {
         auto empty_item = new models::StatusTreeItem(backend::ID_ALL,
-                        std::string("No issues found"), backend::StatusLevel::OK_STATUS, std::string(""));
+                        std::string("No issues found"), backend::StatusLevel::OK_STATUS, std::string(""), std::string(""));
         entity_status_model_->addTopLevelItem(empty_item);
     }
     else
     {
         backend::StatusLevel new_status = backend::StatusLevel::OK_STATUS;
         std::string description = backend::entity_status_description(kind);
+        std::string entity_guid = backend_connection_.get_guid(id);
 
         switch (kind)
         {
@@ -1028,7 +1031,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description);
+                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         std::string handle_string;
                         auto deadline_missed_item = new models::StatusTreeItem(id, kind, std::string("Deadline missed"),
@@ -1053,41 +1056,41 @@ bool Engine::update_entity_status(
             }
             case backend::StatusKind::INCOMPATIBLE_QOS:
             {
-                backend::IncompatibleQosSample sample;
-                if (backend_connection_.get_status_data(id, sample))
-                {
-                    if (sample.status != backend::StatusLevel::OK_STATUS)
-                    {
-                        std::string fastdds_version = "v3.1.0";
-                        backend::StatusLevel entity_status = backend_connection_.get_status(id);
-                        auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description);
-                        new_status = sample.status;
-                        auto incompatible_qos_item = new models::StatusTreeItem(id, kind, std::string(
-                                            "Incompatible QoS"),
-                                        sample.status, std::string(""), description);
-                        for (eprosima::fastdds::statistics::QosPolicyCount_s policy :
-                                sample.incompatible_qos_status.policies())
-                        {
-                            if (policy.count() > 0)
-                            {
-                                auto policy_item = new models::StatusTreeItem(id, kind,
-                                                std::string(backend::policy_id_to_string(policy.policy_id()) + ":"),
-                                                sample.status, std::to_string(policy.count()),
-                                                std::string(
-                                                    "<html><style type=\"text/css\"></style>Check for compatible rules ") +
-                                                std::string(
-                                                    "<a href=\"https://fast-dds.docs.eprosima.com/en/") + fastdds_version +
-                                                std::string("/fastdds/dds_layer/core/policy/standardQosPolicies.html") +
-                                                backend::policy_documentation_description(policy.policy_id()) +
-                                                std::string("\">here</a></html>"));
-                                entity_status_model_->addItem(incompatible_qos_item, policy_item);
-                            }
-                        }
-                        entity_status_model_->addItem(entity_item, incompatible_qos_item);
-                        counter = entity_item->recalculate_entity_counter();
-                    }
-                }
+                // backend::IncompatibleQosSample sample;
+                // if (backend_connection_.get_status_data(id, sample))
+                // {
+                //     if (sample.status != backend::StatusLevel::OK_STATUS)
+                //     {
+                //         std::string fastdds_version = "v3.1.0";
+                //         backend::StatusLevel entity_status = backend_connection_.get_status(id);
+                //         auto entity_item = entity_status_model_->getTopLevelItem(
+                //             id, backend_connection_.get_name(id), entity_status, description, entity_guid);
+                //         new_status = sample.status;
+                //         auto incompatible_qos_item = new models::StatusTreeItem(id, kind, std::string(
+                //                             "Incompatible QoS"),
+                //                         sample.status, std::string(""), description);
+                //         for (eprosima::fastdds::statistics::QosPolicyCount_s policy :
+                //                 sample.incompatible_qos_status.policies())
+                //         {
+                //             if (policy.count() > 0)
+                //             {
+                //                 auto policy_item = new models::StatusTreeItem(id, kind,
+                //                                 std::string(backend::policy_id_to_string(policy.policy_id()) + ":"),
+                //                                 sample.status, std::to_string(policy.count()),
+                //                                 std::string(
+                //                                     "<html><style type=\"text/css\"></style>Check for compatible rules ") +
+                //                                 std::string(
+                //                                     "<a href=\"https://fast-dds.docs.eprosima.com/en/") + fastdds_version +
+                //                                 std::string("/fastdds/dds_layer/core/policy/standardQosPolicies.html") +
+                //                                 backend::policy_documentation_description(policy.policy_id()) +
+                //                                 std::string("\">here</a></html>"));
+                //                 entity_status_model_->addItem(incompatible_qos_item, policy_item);
+                //             }
+                //         }
+                //         entity_status_model_->addItem(entity_item, incompatible_qos_item);
+                //         counter = entity_item->recalculate_entity_counter();
+                //     }
+                // }
                 break;
             }
             case backend::StatusKind::INCONSISTENT_TOPIC:
@@ -1099,7 +1102,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description);
+                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto inconsistent_topic_item =
                                 new models::StatusTreeItem(id, kind, std::string("Inconsistent topics:"),
@@ -1120,7 +1123,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description);
+                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto liveliness_changed_item =
                                 new models::StatusTreeItem(id, kind, std::string("Liveliness changed"),
@@ -1159,7 +1162,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description);
+                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto liveliness_lost_item = new models::StatusTreeItem(id, kind, std::string(
                                             "Liveliness lost:"),
@@ -1180,7 +1183,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description);
+                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto samples_lost_item = new models::StatusTreeItem(id, kind, std::string("Samples lost:"),
                                         sample.status, std::to_string(
@@ -1191,7 +1194,55 @@ bool Engine::update_entity_status(
                 }
                 break;
             }
+            case backend::StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+            {
+                backend::ExtendedIncompatibleQosSample sample;
+                if (backend_connection_.get_status_data(id, sample))
+                {
+                    if (sample.status != backend::StatusLevel::OK_STATUS)
+                    {
+                        std::string fastdds_version = "v3.1.0";
+                        backend::StatusLevel entity_status = backend_connection_.get_status(id);
+                        auto entity_item = entity_status_model_->getTopLevelItem(
+                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
+                        new_status = sample.status;
 
+                        auto incompatible_qos_item = new models::StatusTreeItem(id, kind, std::string(
+                                            "Extended Incompatible QoS"),
+                                        sample.status, std::string(""), description, "", true);
+                        
+                        backend::ExtendedIncompatibleQoSStatusSeq status_seq = sample.extended_incompatible_qos_status;
+
+                        for (auto const& status : status_seq)
+                        {
+                            std::string remote_entity_guid = backend_connection_.get_deserialized_guid(status.remote_guid());
+                            for (const uint32_t policy_id : status.current_incompatible_policies())
+                            {
+                                auto policy_item = new models::StatusTreeItem(id, kind,
+                                                std::string(backend::policy_id_to_string(policy_id) + ":"),
+                                                sample.status, "",
+                                                std::string(
+                                                    "<html><style type=\"text/css\"></style>Check for compatible rules ") +
+                                                std::string(
+                                                    "<a href=\"https://fast-dds.docs.eprosima.com/en/") + fastdds_version +
+                                                std::string("/fastdds/dds_layer/core/policy/standardQosPolicies.html") +
+                                                backend::policy_documentation_description(policy_id) +
+                                                std::string("\">here</a></html>"),
+                                                "", true);
+                                auto remote_entity_item = new models::StatusTreeItem(id, kind,
+                                            std::string("Remote entity: " + remote_entity_guid),
+                                            sample.status, std::string(""), std::string(""), remote_entity_guid, false);
+                                entity_status_model_->addItem(incompatible_qos_item, policy_item);
+                                entity_status_model_->addItem(policy_item, remote_entity_item);
+                            }
+                        }
+
+                        entity_status_model_->addItem(entity_item, incompatible_qos_item);
+                        counter = entity_item->recalculate_entity_counter();
+                    }
+                }
+                break;
+            }
             case backend::StatusKind::CONNECTION_LIST:
             case backend::StatusKind::PROXY:
             //case backend::StatusKind::STATUSES_SIZE:
@@ -1260,14 +1311,14 @@ bool Engine::remove_inactive_entities_from_status_model(
         {
             // remove item from tree
             entity_status_model_->removeItem(entity_status_model_->getTopLevelItem(id, "",
-                    backend::StatusLevel::OK_STATUS, ""));
+                    backend::StatusLevel::OK_STATUS, "", entity_info["guid"]));
 
             // add empty item if removed last item
             if (entity_status_model_->rowCount(entity_status_model_->rootIndex()) == 0)
             {
                 entity_status_model_->addTopLevelItem(new models::StatusTreeItem(
                             backend::ID_ALL, std::string("No issues found"), backend::StatusLevel::OK_STATUS,
-                            std::string("")));
+                            std::string(""), std::string("")));
             }
 
             // update error counter
@@ -1753,6 +1804,63 @@ backend::Graph Engine::get_domain_view_graph (
 {
     return backend_connection_.get_domain_view_graph(domain_id);
 }
+
+// std::set<backend::EntityId> Engine::get_incompatible_entities(
+//         const backend::EntityId& entity_id, uint32_t qos_policy_id)
+// {
+//     std::pair<backend::EntityId, uint32_t> key = std::make_pair(entity_id, qos_policy_id);
+//     auto it = incompatible_qos_policies_.find(key);
+//     if (it != incompatible_qos_policies_.end())
+//     {
+//         return it->second;
+//     }
+//     else
+//     {
+//         return std::set<backend::EntityId>();
+//     }
+// }
+
+// void Engine::update_incompatible_entities(
+//         const backend::EntityId& entity_id, const backend::EntityId& remote_entity_id, uint32_t qos_policy_id)
+// {
+//     std::pair<backend::EntityId, uint32_t> key = std::make_pair(entity_id, qos_policy_id);
+//     auto it = incompatible_qos_policies_.find(key);
+//     if (it != incompatible_qos_policies_.end())
+//     {
+//         it->second.insert(remote_entity_id);
+//     }
+//     else
+//     {
+//         std::set<backend::EntityId> remote_entities;
+//         remote_entities.insert(remote_entity_id);
+//         incompatible_qos_policies_.emplace(entity_id, remote_entities);
+//     }
+// }
+
+// backend::EntityId Engine::get_entity_id_from_guid(
+//         const std::string& guid)
+// {
+//     auto it = guid_entity_id_pairings_.find(guid);
+//     if (it != guid_entity_id_pairings_.end())
+//     {
+//         return it->second;
+//     }
+//     else
+//     {
+//         return backend::EntityId::invalid();
+//     }   
+// }
+
+// void Engine::update_guids(
+//         const backend::EntityId& entity_id)
+// {
+//     if (entity_id == backend::ID_ALL || entity_id == backend::EntityId::invalid())
+//     {
+//         return;
+//     }
+//     std::string entity_guid = backend_connection_.get_guid(entity_id);
+//     guid_entity_id_pairings_.emplace(entity_guid, entity_id);
+// }
 
 bool EntityClicked::is_set() const
 {

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1790,63 +1790,6 @@ backend::Graph Engine::get_domain_view_graph (
     return backend_connection_.get_domain_view_graph(domain_id);
 }
 
-// std::set<backend::EntityId> Engine::get_incompatible_entities(
-//         const backend::EntityId& entity_id, uint32_t qos_policy_id)
-// {
-//     std::pair<backend::EntityId, uint32_t> key = std::make_pair(entity_id, qos_policy_id);
-//     auto it = incompatible_qos_policies_.find(key);
-//     if (it != incompatible_qos_policies_.end())
-//     {
-//         return it->second;
-//     }
-//     else
-//     {
-//         return std::set<backend::EntityId>();
-//     }
-// }
-
-// void Engine::update_incompatible_entities(
-//         const backend::EntityId& entity_id, const backend::EntityId& remote_entity_id, uint32_t qos_policy_id)
-// {
-//     std::pair<backend::EntityId, uint32_t> key = std::make_pair(entity_id, qos_policy_id);
-//     auto it = incompatible_qos_policies_.find(key);
-//     if (it != incompatible_qos_policies_.end())
-//     {
-//         it->second.insert(remote_entity_id);
-//     }
-//     else
-//     {
-//         std::set<backend::EntityId> remote_entities;
-//         remote_entities.insert(remote_entity_id);
-//         incompatible_qos_policies_.emplace(entity_id, remote_entities);
-//     }
-// }
-
-// backend::EntityId Engine::get_entity_id_from_guid(
-//         const std::string& guid)
-// {
-//     auto it = guid_entity_id_pairings_.find(guid);
-//     if (it != guid_entity_id_pairings_.end())
-//     {
-//         return it->second;
-//     }
-//     else
-//     {
-//         return backend::EntityId::invalid();
-//     }
-// }
-
-// void Engine::update_guids(
-//         const backend::EntityId& entity_id)
-// {
-//     if (entity_id == backend::ID_ALL || entity_id == backend::EntityId::invalid())
-//     {
-//         return;
-//     }
-//     std::string entity_guid = backend_connection_.get_guid(entity_id);
-//     guid_entity_id_pairings_.emplace(entity_guid, entity_id);
-// }
-
 bool EntityClicked::is_set() const
 {
     return kind != backend::EntityKind::INVALID;

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1011,7 +1011,8 @@ bool Engine::update_entity_status(
     if (id == backend::ID_ALL)
     {
         auto empty_item = new models::StatusTreeItem(backend::ID_ALL,
-                        std::string("No issues found"), backend::StatusLevel::OK_STATUS, std::string(""), std::string(""));
+                        std::string("No issues found"), backend::StatusLevel::OK_STATUS, std::string(""), std::string(
+                            ""));
         entity_status_model_->addTopLevelItem(empty_item);
     }
     else
@@ -1171,12 +1172,13 @@ bool Engine::update_entity_status(
                         auto incompatible_qos_item = new models::StatusTreeItem(id, kind, std::string(
                                             "Extended Incompatible QoS"),
                                         sample.status, std::string(""), description, "", true);
-                        
+
                         backend::ExtendedIncompatibleQoSStatusSeq status_seq = sample.extended_incompatible_qos_status;
 
                         for (auto const& status : status_seq)
                         {
-                            std::string remote_entity_guid = backend_connection_.get_deserialized_guid(status.remote_guid());
+                            std::string remote_entity_guid = backend_connection_.get_deserialized_guid(
+                                status.remote_guid());
                             controller_->status_counters.shared_errors[id][remote_entity_guid] = 0;
                             for (const uint32_t policy_id : status.current_incompatible_policies())
                             {
@@ -1192,10 +1194,11 @@ bool Engine::update_entity_status(
                                                 std::string("\">here</a></html>"),
                                                 "", true);
                                 auto remote_entity_item = new models::StatusTreeItem(id, kind,
-                                            std::string("Remote entity: " + remote_entity_guid),
-                                            sample.status, std::string(""), std::string(""), remote_entity_guid, false);
+                                                std::string("Remote entity: " + remote_entity_guid),
+                                                sample.status, std::string(""), std::string(
+                                                    ""), remote_entity_guid, false);
                                 entity_status_model_->addItem(incompatible_qos_item, policy_item);
-                                entity_status_model_->addItem(policy_item, remote_entity_item); 
+                                entity_status_model_->addItem(policy_item, remote_entity_item);
                                 controller_->status_counters.shared_errors[id][remote_entity_guid] += 1;
                             }
                         }
@@ -1830,7 +1833,7 @@ backend::Graph Engine::get_domain_view_graph (
 //     else
 //     {
 //         return backend::EntityId::invalid();
-//     }   
+//     }
 // }
 
 // void Engine::update_guids(

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -643,6 +643,12 @@ std::string SyncBackendConnection::get_data_type_name(
     return backend::get_info_value(get_info(id), "data_type");
 }
 
+std::string SyncBackendConnection::get_guid(
+        backend::EntityId id)
+{
+    return backend::get_info_value(get_info(id), "guid");
+}
+
 StatusLevel SyncBackendConnection:: get_status(
         EntityId id)
 {
@@ -907,6 +913,33 @@ bool SyncBackendConnection::get_status_data(
     }
     return false;
 }
+
+bool SyncBackendConnection::get_status_data(
+        EntityId id,
+        ExtendedIncompatibleQosSample& sample)
+{
+    try
+    {
+        StatisticsBackend::get_status_data(id, sample);
+        return true;
+    }
+    catch (const Error& e)
+    {
+        qWarning() << "Error retrieving sample: " << e.what();
+    }
+    catch (const BadParameter& e)
+    {
+        qWarning() << "Bad Parameter retrieving sample " << e.what();
+    }
+    return false;
+}
+
+std::string SyncBackendConnection::get_deserialized_guid(
+        const backend::GUID_s& data)
+{
+    return StatisticsBackend::deserialize_guid(data);
+}
+
 
 bool SyncBackendConnection::build_source_target_entities_vectors(
         DataKind data_kind,

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -1485,7 +1485,9 @@ bool SyncBackendConnection::update_one_entity_in_model_(
         // If it didnt exist yet something has gone wrong in backend
         if (!new_entity)
         {
+            #ifdef QT_DEBUG
             qWarning() << "Trying to update an entity that did not exist";
+            #endif // ifdef QT_DEBUG
         }
 
         // Get alive status and metatraffic attribute of entity.

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -940,7 +940,6 @@ std::string SyncBackendConnection::get_deserialized_guid(
     return StatisticsBackend::deserialize_guid(data);
 }
 
-
 bool SyncBackendConnection::build_source_target_entities_vectors(
         DataKind data_kind,
         EntityId source_entity_id,

--- a/src/backend/backend_utils.cpp
+++ b/src/backend/backend_utils.cpp
@@ -27,6 +27,7 @@
 #include <fastdds_monitor/model/model_types.h>
 #include <fastdds_monitor/utils.h>
 #include <fastdds_statistics_backend/types/JSONTags.h>
+#include <fastdds_statistics_backend/topic_types/types.hpp>
 
 #include <QDebug>
 
@@ -147,6 +148,8 @@ std::string status_kind_to_string(
             return "SAMPLE_LOST";
         case StatusKind::STATUSES_SIZE:
             return "STATUSES_SIZE";
+        case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+            return "EXTENDED_INCOMPATIBLE_QOS";
         case StatusKind::INVALID:
         default:
             return "INVALID";
@@ -517,6 +520,8 @@ std::string entity_status_description(
             return "Collection of Parameters describing the Proxy Data of the entity";
         case backend::StatusKind::SAMPLE_LOST:
             return "Tracks the number of times that the entity lost samples";
+        case backend::StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+            return "Tracks the current incompatible QoS policies of the entity with another remote entity";
         //case backend::StatusKind::STATUSES_SIZE:
         //    return "";
         default:

--- a/src/model/tree/StatusTreeItem.cpp
+++ b/src/model/tree/StatusTreeItem.cpp
@@ -175,9 +175,6 @@ StatusTreeItem::StatusTreeItem(
 
 StatusTreeItem::~StatusTreeItem()
 {
-    // __FLAG__
-    // std::cout << "[StatusTreeItem] Calling destructor for item: " << name_ << std::endl;
-    ///////////////////////////
     qDeleteAll(child_items_);
     emit itemRemoved(guid_);
 }
@@ -407,9 +404,6 @@ int StatusTreeItem::recalculate_entity_counter()
 void StatusTreeItem::onItemRemoved(
         std::string guid)
 {
-    // __FLAG__
-    std::cout << "[StatusTreeItem]Item removed with guid: " << guid << std::endl;
-
     if (guid_ == guid)
     {
         remove();

--- a/src/model/tree/StatusTreeItem.cpp
+++ b/src/model/tree/StatusTreeItem.cpp
@@ -394,9 +394,10 @@ int StatusTreeItem::recalculate_entity_counter()
     // check if top level item / entity item
     if (id_ != backend::ID_ALL && kind_ == backend::StatusKind::INVALID)
     {
-        int count = leafCount();
+        count = leafCount();
         value_ = std::to_string(count);
         value_variant_ = QVariant(QString::fromStdString(value_));
+        return count;
     }
     return count;
 }

--- a/src/model/tree/StatusTreeItem.cpp
+++ b/src/model/tree/StatusTreeItem.cpp
@@ -53,10 +53,12 @@ StatusTreeItem::StatusTreeItem()
     , id_(backend::ID_ALL)
     , kind_(backend::StatusKind::INVALID)
     , name_()
+    , guid_()
     , status_level_(backend::StatusLevel::OK_STATUS)
     , value_()
     , description_()
     , is_active_(true)
+    , delete_if_no_children_(false)
     , id_variant_(QVariant(backend::backend_id_to_models_id(id_)))
     , kind_variant_(QVariant(QString::fromStdString(backend::status_kind_to_string(kind_))))
     , name_variant_(QVariant())
@@ -73,10 +75,12 @@ StatusTreeItem::StatusTreeItem(
     , id_(backend::ID_ALL)
     , kind_(backend::StatusKind::INVALID)
     , name_(data.toString().toStdString())
+    , guid_()
     , status_level_(backend::StatusLevel::OK_STATUS)
     , value_()
     , description_()
     , is_active_(true)
+    , delete_if_no_children_(false)
     , id_variant_(QVariant(backend::backend_id_to_models_id(id_)))
     , kind_variant_(QVariant(QString::fromStdString(backend::status_kind_to_string(kind_))))
     , name_variant_(QVariant(QString::fromStdString(name_)))
@@ -91,15 +95,18 @@ StatusTreeItem::StatusTreeItem(
         const backend::EntityId& id,
         const std::string& name,
         const backend::StatusLevel& status_level,
-        const std::string& description)
+        const std::string& description,
+        const std::string& guid)
     : parent_item_(nullptr)
     , id_(id)
     , kind_(backend::StatusKind::INVALID)
     , name_(name)
+    , guid_(guid)
     , status_level_(status_level)
     , value_()
     , description_(description)
     , is_active_(true)
+    , delete_if_no_children_(true)
     , id_variant_(QVariant(backend::backend_id_to_models_id(id_)))
     , kind_variant_(QVariant(QString::fromStdString(backend::status_kind_to_string(kind_))))
     , name_variant_(QVariant(QString::fromStdString(name)))
@@ -121,10 +128,41 @@ StatusTreeItem::StatusTreeItem(
     , id_(id)
     , kind_(kind)
     , name_(name)
+    , guid_()
     , status_level_(status_level)
     , value_(value)
     , description_(description)
     , is_active_(true)
+    , delete_if_no_children_(false)
+    , id_variant_(QVariant(backend::backend_id_to_models_id(id_)))
+    , kind_variant_(QVariant(QString::fromStdString(backend::status_kind_to_string(kind_))))
+    , name_variant_(QVariant(QString::fromStdString(name_)))
+    , status_level_variant_(QVariant(QString::fromStdString(backend::status_level_to_string(status_level_))))
+    , value_variant_(QVariant(QString::fromStdString(value)))
+    , description_variant_(QVariant(QString::fromStdString(description)))
+    , is_active_variant_(QVariant(true))
+{
+}
+
+StatusTreeItem::StatusTreeItem(
+        const backend::EntityId& id,
+        const backend::StatusKind& kind,
+        const std::string& name,
+        const backend::StatusLevel& status_level,
+        const std::string& value,
+        const std::string& description,
+        const std::string& guid,
+        bool delete_if_no_children)
+    : parent_item_(nullptr)
+    , id_(id)
+    , kind_(kind)
+    , name_(name)
+    , guid_(guid)
+    , status_level_(status_level)
+    , value_(value)
+    , description_(description)
+    , is_active_(true)
+    , delete_if_no_children_(delete_if_no_children)
     , id_variant_(QVariant(backend::backend_id_to_models_id(id_)))
     , kind_variant_(QVariant(QString::fromStdString(backend::status_kind_to_string(kind_))))
     , name_variant_(QVariant(QString::fromStdString(name_)))
@@ -137,7 +175,11 @@ StatusTreeItem::StatusTreeItem(
 
 StatusTreeItem::~StatusTreeItem()
 {
+    // __FLAG__
+    // std::cout << "[StatusTreeItem] Calling destructor for item: " << name_ << std::endl;
+    ///////////////////////////
     qDeleteAll(child_items_);
+    emit itemRemoved(guid_);
 }
 
 StatusTreeItem* StatusTreeItem::parentItem()
@@ -168,6 +210,8 @@ void StatusTreeItem::removeChild(
         child_items_.removeAll(item);
         delete item;
     }
+
+    this->delete_if_no_children();
 }
 
 StatusTreeItem* StatusTreeItem::child(
@@ -179,6 +223,26 @@ StatusTreeItem* StatusTreeItem::child(
 int StatusTreeItem::childCount() const
 {
     return child_items_.count();
+}
+
+int StatusTreeItem::descendantCount() const
+{
+    int count = 0;
+    for (int i = 0; i < child_items_.count(); i++)
+    {
+        count += child_items_.value(i)->descendantCount();
+    }
+    return count + child_items_.count();
+}
+
+int StatusTreeItem::leafCount() const
+{
+    int count = 0;
+    for (int i = 0; i < child_items_.count(); i++)
+    {
+        count += child_items_.value(i)->leafCount();
+    }
+    return count + int(child_items_.isEmpty());
 }
 
 const QVariant& StatusTreeItem::entity_id() const
@@ -277,6 +341,11 @@ std::string StatusTreeItem::name_str()
     return name_;
 }
 
+std::string StatusTreeItem::guid_str()
+{
+    return guid_;
+}
+
 std::string StatusTreeItem::value_str()
 {
     return value_;
@@ -287,33 +356,63 @@ std::string StatusTreeItem::description_str()
     return description_;
 }
 
+bool StatusTreeItem::get_delete_if_no_children()
+{
+    return delete_if_no_children_;
+}
+
+void StatusTreeItem::set_delete_if_no_children(
+        bool delete_if_no_children)
+{
+    delete_if_no_children_ = delete_if_no_children;
+}
+
+void StatusTreeItem::delete_if_no_children()
+{
+    if (delete_if_no_children_ && child_items_.isEmpty())
+    {
+        remove();
+    }
+}
+
+void StatusTreeItem::remove()
+{
+    if (parent_item_)
+    {
+        parent_item_->removeChild(this);
+    }
+
+    else
+    {
+        delete this;
+    }
+}
+
 int StatusTreeItem::recalculate_entity_counter()
 {
     int count = 0;
     // check if top level item / entity item
     if (id_ != backend::ID_ALL && kind_ == backend::StatusKind::INVALID)
     {
-        for (int i = 0; i < child_items_.count(); i++)
-        {
-            try
-            {
-                if (child_items_.value(i)->childCount() > 0)
-                {
-                    for (int j = 0; j < child_items_.value(i)->childCount(); j++)
-                    {
-                        count += child_items_.value(i)->child(j)->value().toInt();
-                    }
-                }
-                count += child_items_.value(i)->value().toInt();
-            }
-            catch (...)
-            {
-            }
-        }
+        int count = leafCount();
         value_ = std::to_string(count);
         value_variant_ = QVariant(QString::fromStdString(value_));
     }
     return count;
+}
+
+// Slots
+
+void StatusTreeItem::onItemRemoved(
+        std::string guid)
+{
+    // __FLAG__
+    std::cout << "[StatusTreeItem]Item removed with guid: " << guid << std::endl;
+
+    if (guid_ == guid)
+    {
+        remove();
+    }
 }
 
 } // namespace models

--- a/src/model/tree/StatusTreeModel.cpp
+++ b/src/model/tree/StatusTreeModel.cpp
@@ -61,6 +61,7 @@ StatusTreeModel::StatusTreeModel(
 
 StatusTreeModel::~StatusTreeModel()
 {
+    disconnect_all_item_signals();
     delete root_item_;
 }
 

--- a/src/model/tree/StatusTreeModel.cpp
+++ b/src/model/tree/StatusTreeModel.cpp
@@ -333,13 +333,13 @@ void StatusTreeModel::addTopLevelItem(
         {
             is_empty_ = true;
         }
-        
+
         if (child->status_level() == backend::StatusLevel::ERROR_STATUS)
         {
             // Notify entity item destruction
             QObject::connect(child, &StatusTreeItem::itemRemoved, this, &StatusTreeModel::onItemRemoved);
         }
-        
+
     }
 }
 
@@ -373,24 +373,10 @@ void StatusTreeModel::addItem(
             }
         }
     }
-    else if(child->isLeaf() && child->kind() == backend::StatusKind::EXTENDED_INCOMPATIBLE_QOS)
+    else if (child->isLeaf() && child->kind() == backend::StatusKind::EXTENDED_INCOMPATIBLE_QOS)
     {
-        // __FLAG__
-        std::cout << "[StatusTreeModel] Adding child to parent && linking signals. Parent: " << parent->name_str() << " child: " << child->name_str() << std::endl;
         QObject::connect(this, &StatusTreeModel::itemRemoved, child, &StatusTreeItem::onItemRemoved);
     }
-    // else if (parent->id() != backend::ID_ALL && parent->kind() == backend::StatusKind::EXTENDED_INCOMPATIBLE_QOS)
-    // {
-    //     bool 
-    //     for (int i = 0; i < parent->childCount(); i++)
-    //     {
-    //         if (parent->child(i)->name_str() == child->name_str())
-    //         {
-                
-    //             return;
-    //         }
-    //     }
-    // }
 
     emit layoutAboutToBeChanged();
 
@@ -464,8 +450,6 @@ void StatusTreeModel::clear()
 {
     emit layoutAboutToBeChanged();
     beginResetModel();
-    // __FLAG__
-    std::cout << "[StatusTreeModel] Clearing model" << std::endl;
     // NOTE: When the root item is deleted, all its children are also deleted. This causes every leaf node to receive a signal notifying the destruction
     // of every entity item, which is unnecessary. Disconnecting all signal-slot communications between the TreeModel and leaf nodes (i.e., disconnecting
     // all slots connected to the TreeModel's itemRemoved signal) before deleting the root item prevents this behavior.
@@ -569,8 +553,6 @@ StatusTreeItem*  StatusTreeModel::getTopLevelItem(
 void StatusTreeModel::onItemRemoved(
         std::string guid)
 {
-    // __FLAG__
-    std::cout << "[StatusTreeModel] Calling onItemRemoved for item with guid: " << guid << std::endl;
     emit itemRemoved(guid);
 }
 


### PR DESCRIPTION
# Main changes
- Add support to Extended Incompatible QoS samples
- Improve problems view: Now, it shows incompatible remote endpoint guids and refresh automatically when an endpoints disappears.


This PR must be merged after:
- https://github.com/eProsima/Fast-DDS-statistics-backend/pull/257