### PR TITLE
[22705] Fix counters and change endpoint names in problems view

### DIFF
--- a/include/fastdds_monitor/backend/SyncBackendConnection.h
+++ b/include/fastdds_monitor/backend/SyncBackendConnection.h
@@ -118,7 +118,7 @@ public:
 
     //! Get entity by GUID in string format
     backend::EntityId get_entity_by_guid(
-        const std::string& guid);
+            const std::string& guid);
 
     //! Get a summary of important data collected from the backend related with the entity with id \c id
     EntityInfo get_summary(

--- a/include/fastdds_monitor/backend/SyncBackendConnection.h
+++ b/include/fastdds_monitor/backend/SyncBackendConnection.h
@@ -116,6 +116,10 @@ public:
     EntityKind get_type(
             backend::EntityId id);
 
+    //! Get entity by GUID in string format
+    backend::EntityId get_entity_by_guid(
+        const std::string& guid);
+
     //! Get a summary of important data collected from the backend related with the entity with id \c id
     EntityInfo get_summary(
             backend::EntityId id);
@@ -210,6 +214,10 @@ public:
     //! Convert a given entity guid to string format
     std::string get_deserialized_guid(
             const backend::GUID_s& data);
+
+    //! Convert a given entity guid in string format to GUID_s
+    backend::GUID_s get_serialize_guid(
+            const std::string& guid_str);
 
     //! Get info from an entity from the Backend
     std::vector<EntityId> get_entities(

--- a/include/fastdds_monitor/model/tree/StatusTreeItem.h
+++ b/include/fastdds_monitor/model/tree/StatusTreeItem.h
@@ -128,6 +128,10 @@ public:
     //! Return the number of leaf nodes of the subtree rooted at this node
     int leafCount() const;
 
+    //! Return the number of leaf nodes of the subtree rooted at this node with a specific status level
+    int filteredLeafCount(
+            backend::StatusLevel status_level) const;
+
     int row() const;
 
     //! Return true if the node is a leaf node (no children).
@@ -169,8 +173,8 @@ public:
     //! Remove item from tree and delete it
     void remove();
 
-    //! Increases the issues counter of a top level entity item
-    int recalculate_entity_counter();
+    //! Increases the issues (warnings or errors) counter of a top level entity item
+    int recalculate_entity_counter(backend::StatusLevel status_level);
 
 private:
 

--- a/include/fastdds_monitor/model/tree/StatusTreeItem.h
+++ b/include/fastdds_monitor/model/tree/StatusTreeItem.h
@@ -174,7 +174,8 @@ public:
     void remove();
 
     //! Increases the issues (warnings or errors) counter of a top level entity item
-    int recalculate_entity_counter(backend::StatusLevel status_level);
+    int recalculate_entity_counter(
+            backend::StatusLevel status_level);
 
 private:
 

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1050,7 +1050,7 @@ bool Engine::update_entity_status(
                         entity_status_model_->addItem(deadline_missed_item, total_count_item);
                         entity_status_model_->addItem(deadline_missed_item, last_instance_handle_item);
                         entity_status_model_->addItem(entity_item, deadline_missed_item);
-                        counter = entity_item->recalculate_entity_counter();
+                        counter = entity_item->recalculate_entity_counter(sample.status);
                     }
                 }
                 break;
@@ -1071,7 +1071,7 @@ bool Engine::update_entity_status(
                                         sample.status, std::to_string(
                                             sample.inconsistent_topic_status.total_count()), description);
                         entity_status_model_->addItem(entity_item, inconsistent_topic_item);
-                        counter = entity_item->recalculate_entity_counter();
+                        counter = entity_item->recalculate_entity_counter(sample.status);
                     }
                 }
                 break;
@@ -1110,7 +1110,7 @@ bool Engine::update_entity_status(
                         entity_status_model_->addItem(liveliness_changed_item, not_alive_count_item);
                         entity_status_model_->addItem(liveliness_changed_item, last_publication_handle_item);
                         entity_status_model_->addItem(entity_item, liveliness_changed_item);
-                        counter = entity_item->recalculate_entity_counter();
+                        counter = entity_item->recalculate_entity_counter(sample.status);
                     }
                 }
                 break;
@@ -1131,7 +1131,7 @@ bool Engine::update_entity_status(
                                         sample.status, std::to_string(
                                             sample.liveliness_lost_status.total_count()), description);
                         entity_status_model_->addItem(entity_item, liveliness_lost_item);
-                        counter = entity_item->recalculate_entity_counter();
+                        counter = entity_item->recalculate_entity_counter(sample.status);
                     }
                 }
                 break;
@@ -1151,7 +1151,7 @@ bool Engine::update_entity_status(
                                         sample.status, std::to_string(
                                             sample.sample_lost_status.total_count()), description);
                         entity_status_model_->addItem(entity_item, samples_lost_item);
-                        counter = entity_item->recalculate_entity_counter();
+                        counter = entity_item->recalculate_entity_counter(sample.status);
                     }
                 }
                 break;
@@ -1204,7 +1204,7 @@ bool Engine::update_entity_status(
                         }
 
                         entity_status_model_->addItem(entity_item, incompatible_qos_item);
-                        counter = entity_item->recalculate_entity_counter();
+                        counter = entity_item->recalculate_entity_counter(sample.status);
                     }
                 }
                 break;

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1193,8 +1193,23 @@ bool Engine::update_entity_status(
                                                 backend::policy_documentation_description(policy_id) +
                                                 std::string("\">here</a></html>"),
                                                 "", true);
+                                std::string remote_entity;
+                                backend::EntityId remote_entity_id = backend_connection_.get_entity_by_guid(remote_entity_guid);
+                                if (remote_entity_id.is_valid())
+                                {
+                                    EntityInfo entity_info = backend_connection_.get_info(remote_entity_id);
+                                    std::string remote_entity_kind = utils::to_string(
+                                        backend::entity_kind_to_QString(backend_connection_.get_type(remote_entity_id)));
+                                    std::stringstream ss;
+                                    ss << std::string(entity_info["alias"]) << " (" << remote_entity_kind << ")";
+                                    remote_entity = ss.str();
+                                }
+                                else
+                                {
+                                    remote_entity = remote_entity_guid;
+                                }
                                 auto remote_entity_item = new models::StatusTreeItem(id, kind,
-                                                std::string("Remote entity: " + remote_entity_guid),
+                                                std::string("Remote entity: " + remote_entity),
                                                 sample.status, std::string(""), std::string(
                                                     ""), remote_entity_guid, false);
                                 entity_status_model_->addItem(incompatible_qos_item, policy_item);

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1020,7 +1020,7 @@ bool Engine::update_entity_status(
         backend::StatusLevel new_status = backend::StatusLevel::OK_STATUS;
         std::string description = backend::entity_status_description(kind);
         std::string entity_guid = backend_connection_.get_guid(id);
-
+        std::string entity_kind = utils::to_string(backend::entity_kind_to_QString(backend_connection_.get_type(id)));
         switch (kind)
         {
             case backend::StatusKind::DEADLINE_MISSED:
@@ -1032,7 +1032,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         std::string handle_string;
                         auto deadline_missed_item = new models::StatusTreeItem(id, kind, std::string("Deadline missed"),
@@ -1064,7 +1064,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto inconsistent_topic_item =
                                 new models::StatusTreeItem(id, kind, std::string("Inconsistent topics:"),
@@ -1085,7 +1085,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto liveliness_changed_item =
                                 new models::StatusTreeItem(id, kind, std::string("Liveliness changed"),
@@ -1124,7 +1124,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto liveliness_lost_item = new models::StatusTreeItem(id, kind, std::string(
                                             "Liveliness lost:"),
@@ -1145,7 +1145,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto samples_lost_item = new models::StatusTreeItem(id, kind, std::string("Samples lost:"),
                                         sample.status, std::to_string(
@@ -1166,7 +1166,7 @@ bool Engine::update_entity_status(
                         std::string fastdds_version = "v3.1.0";
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
 
                         auto incompatible_qos_item = new models::StatusTreeItem(id, kind, std::string(

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1032,7 +1032,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         std::string handle_string;
                         auto deadline_missed_item = new models::StatusTreeItem(id, kind, std::string("Deadline missed"),
@@ -1064,7 +1064,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto inconsistent_topic_item =
                                 new models::StatusTreeItem(id, kind, std::string("Inconsistent topics:"),
@@ -1085,7 +1085,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto liveliness_changed_item =
                                 new models::StatusTreeItem(id, kind, std::string("Liveliness changed"),
@@ -1124,7 +1124,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto liveliness_lost_item = new models::StatusTreeItem(id, kind, std::string(
                                             "Liveliness lost:"),
@@ -1145,7 +1145,7 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto samples_lost_item = new models::StatusTreeItem(id, kind, std::string("Samples lost:"),
                                         sample.status, std::to_string(
@@ -1166,7 +1166,7 @@ bool Engine::update_entity_status(
                         std::string fastdds_version = "v3.1.0";
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + "_" + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
                         new_status = sample.status;
 
                         auto incompatible_qos_item = new models::StatusTreeItem(id, kind, std::string(

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1032,7 +1032,8 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(
+                                id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         std::string handle_string;
                         auto deadline_missed_item = new models::StatusTreeItem(id, kind, std::string("Deadline missed"),
@@ -1064,7 +1065,8 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(
+                                id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto inconsistent_topic_item =
                                 new models::StatusTreeItem(id, kind, std::string("Inconsistent topics:"),
@@ -1085,7 +1087,8 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(
+                                id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto liveliness_changed_item =
                                 new models::StatusTreeItem(id, kind, std::string("Liveliness changed"),
@@ -1124,7 +1127,8 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(
+                                id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto liveliness_lost_item = new models::StatusTreeItem(id, kind, std::string(
                                             "Liveliness lost:"),
@@ -1145,7 +1149,8 @@ bool Engine::update_entity_status(
                     {
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(
+                                id), entity_status, description, entity_guid);
                         new_status = sample.status;
                         auto samples_lost_item = new models::StatusTreeItem(id, kind, std::string("Samples lost:"),
                                         sample.status, std::to_string(
@@ -1166,7 +1171,8 @@ bool Engine::update_entity_status(
                         std::string fastdds_version = "v3.1.0";
                         backend::StatusLevel entity_status = backend_connection_.get_status(id);
                         auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(id), entity_status, description, entity_guid);
+                            id, entity_kind + ": " + backend_connection_.get_name(
+                                id), entity_status, description, entity_guid);
                         new_status = sample.status;
 
                         auto incompatible_qos_item = new models::StatusTreeItem(id, kind, std::string(
@@ -1194,7 +1200,8 @@ bool Engine::update_entity_status(
                                                 std::string("\">here</a></html>"),
                                                 "", true);
                                 std::string remote_entity;
-                                backend::EntityId remote_entity_id = backend_connection_.get_entity_by_guid(remote_entity_guid);
+                                backend::EntityId remote_entity_id = backend_connection_.get_entity_by_guid(
+                                    remote_entity_guid);
                                 if (remote_entity_id.is_valid())
                                 {
                                     EntityInfo entity_info = backend_connection_.get_info(remote_entity_id);

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -555,6 +555,22 @@ EntityKind SyncBackendConnection::get_type(
     }
 }
 
+backend::EntityId SyncBackendConnection::get_entity_by_guid(
+        const std::string& guid)
+{
+    try
+    {
+        return StatisticsBackend::get_entity_by_guid(guid);
+    }
+    catch (const Exception& e)
+    {
+        qWarning() << "Fail getting entity by guid " << e.what();
+        static_cast<void>(e); // In release qWarning does not compile and so e is not used
+
+        return EntityId::invalid();
+    }
+}
+
 std::vector<EntityId> SyncBackendConnection::get_entities(
         EntityKind entity_type,
         EntityId entity_id)
@@ -938,6 +954,20 @@ std::string SyncBackendConnection::get_deserialized_guid(
         const backend::GUID_s& data)
 {
     return StatisticsBackend::deserialize_guid(data);
+}
+
+backend::GUID_s SyncBackendConnection::get_serialize_guid(
+        const std::string& guid_str)
+{
+    try
+    {
+        return StatisticsBackend::serialize_guid(guid_str);
+    }
+    catch(const std::exception& e)
+    {
+        qWarning() << "Error generating GUID from string " << e.what();
+    }
+    return backend::GUID_s();
 }
 
 bool SyncBackendConnection::build_source_target_entities_vectors(

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -963,7 +963,7 @@ backend::GUID_s SyncBackendConnection::get_serialize_guid(
     {
         return StatisticsBackend::serialize_guid(guid_str);
     }
-    catch(const std::exception& e)
+    catch (const std::exception& e)
     {
         qWarning() << "Error generating GUID from string " << e.what();
     }

--- a/src/model/tree/StatusTreeItem.cpp
+++ b/src/model/tree/StatusTreeItem.cpp
@@ -242,7 +242,8 @@ int StatusTreeItem::leafCount() const
     return count + int(child_items_.isEmpty());
 }
 
-int StatusTreeItem::filteredLeafCount(backend::StatusLevel status_level) const
+int StatusTreeItem::filteredLeafCount(
+        backend::StatusLevel status_level) const
 {
     int count = 0;
     for (int i = 0; i < child_items_.count(); i++)
@@ -254,6 +255,7 @@ int StatusTreeItem::filteredLeafCount(backend::StatusLevel status_level) const
     }
     return count + int(child_items_.isEmpty() && status_level == status_level_);
 }
+
 const QVariant& StatusTreeItem::entity_id() const
 {
     return id_variant_;
@@ -397,7 +399,8 @@ void StatusTreeItem::remove()
     }
 }
 
-int StatusTreeItem::recalculate_entity_counter(backend::StatusLevel status_level)
+int StatusTreeItem::recalculate_entity_counter(
+        backend::StatusLevel status_level)
 {
     int count = 0;
     // check if top level item / entity item

--- a/src/model/tree/StatusTreeItem.cpp
+++ b/src/model/tree/StatusTreeItem.cpp
@@ -242,6 +242,18 @@ int StatusTreeItem::leafCount() const
     return count + int(child_items_.isEmpty());
 }
 
+int StatusTreeItem::filteredLeafCount(backend::StatusLevel status_level) const
+{
+    int count = 0;
+    for (int i = 0; i < child_items_.count(); i++)
+    {
+        if (child_items_.value(i)->status_level() == status_level)
+        {
+            count += child_items_.value(i)->filteredLeafCount(status_level);
+        }
+    }
+    return count + int(child_items_.isEmpty() && status_level == status_level_);
+}
 const QVariant& StatusTreeItem::entity_id() const
 {
     return id_variant_;
@@ -385,14 +397,15 @@ void StatusTreeItem::remove()
     }
 }
 
-int StatusTreeItem::recalculate_entity_counter()
+int StatusTreeItem::recalculate_entity_counter(backend::StatusLevel status_level)
 {
     int count = 0;
     // check if top level item / entity item
     if (id_ != backend::ID_ALL && kind_ == backend::StatusKind::INVALID)
     {
-        count = leafCount();
-        value_ = std::to_string(count);
+        count = filteredLeafCount(status_level);
+        // update total number of issues (warnings + errors) related to this item
+        value_ = std::to_string(leafCount());
         value_variant_ = QVariant(QString::fromStdString(value_));
         return count;
     }


### PR DESCRIPTION
## Main changes

This PR fixes a bug in warning counters caused by the refactor of the problems view. Total warnings counter is not displayed correctly (it shows the same number as error counter).
It also adds an endpoint kind prefix to endpoint names.

It must be merged after:
- https://github.com/eProsima/Fast-DDS-statistics-backend/pull/264