### PR TITLE
[23518] Fix Domain Graph View in Discovery Server Monitor

### DIFF
--- a/qml/DomainGraphLayout.qml
+++ b/qml/DomainGraphLayout.qml
@@ -1500,7 +1500,7 @@ Item
             var new_model = JSON.parse(model_string)
 
             // Ensure expected graph was received
-            if (new_model["domain"] == domain_id)
+            if (new_model["domain_info"]["domain_id"] == domain_id)
             {
                 var is_metatraffic_visible_ = controller.metatraffic_visible();
 
@@ -1682,7 +1682,7 @@ Item
                 }
                 model = {
                     "kind": new_model["kind"],
-                    "domain": new_model["domain"],
+                    "domain": new_model["domain_info"]["domain_id"],
                     "topics": new_topics,
                     "hosts": new_hosts,
                 }


### PR DESCRIPTION
# Main Changes

This PR addresses an issue that was reported when attempting to display the Domain Graph View on a Discovery Server Monitor. As the domain name of the Domain Graph does not correspond to its Domain ID, the validity checks always fail, returning an empty model. This issue has been resolved by using the new 'domain_id' of the backend's Domain Graph in the comparison.

This PR  should be merged after:

- https://github.com/eProsima/Fast-DDS-statistics-backend/pull/283