### PR TITLE
Removing emissions of remove signals that dont work with qt15

### DIFF
--- a/src/model/tree/TreeModel.cpp
+++ b/src/model/tree/TreeModel.cpp
@@ -420,9 +420,7 @@ void TreeModel::setup_model_data_without_clean(
 
         if (!newKeys.contains(name))
         {
-            beginRemoveRows(parent_index, i, i);
             child = parent->take_child_item(i);
-            endRemoveRows();
             delete child;
         }
     }


### PR DESCRIPTION
There was an issue when changing the spy mode from a highly changing type with a high frequency to a simpler one. The problem arised when emitting RemoveRows signals, that were not really used as the update had to be done more manually due to the limitations of Qt15 TreeModel. Hence, the emission of those signals has been removed.