### PR TITLE
Hotfix/spy close button segfault

### DIFF
--- a/include/fastdds_monitor/Engine.h
+++ b/include/fastdds_monitor/Engine.h
@@ -931,7 +931,7 @@ protected:
     // Variables
 
     //! Set to true if the engine is being enabled
-    bool enabled_;
+    std::atomic<bool> enabled_;
 
     //! Reference to the \c Listener that is being set to the backend as callback communicator
     backend::Listener* listener_;

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -211,6 +211,7 @@ Engine::~Engine()
 {
     if  (enabled_)
     {
+        enabled_ = false;
         // First free the listener to stop new entities from appear
         if (listener_)
         {
@@ -450,10 +451,16 @@ void Engine::start_topic_spy(
                     try
                     {
                         json_data = backend::refactor_json_ordered(UserDataInfo::parse(data));
-                        QMetaObject::invokeMethod(user_data_model_, [this, json_data]() mutable
+                        if (this->enabled_)
                         {
-                            user_data_model_->update_without_clean(json_data);
-                        }, Qt::QueuedConnection);
+                            QMetaObject::invokeMethod(user_data_model_, [this, json_data]() mutable
+                            {
+                                if (user_data_model_)
+                                {
+                                    user_data_model_->update_without_clean(json_data);
+                                }
+                            }, Qt::QueuedConnection);
+                        }
                     }
                     catch (const std::exception& /*e*/)
                     {


### PR DESCRIPTION
When closing the monitor while an active spy was run, the enqueued tasks in the QML thread produced a segfault. This is fixed checking an "enabled" boolean at the engine level (that already existed)