### PR TITLE
[#24444] Fixed Qt model protocol violations with emit 'layoutChanged'

### DIFF
--- a/include/fastdds_monitor/backend/SyncBackendConnection.h
+++ b/include/fastdds_monitor/backend/SyncBackendConnection.h
@@ -282,13 +282,6 @@ public:
     void clear_statistics_data(
             Timestamp time_to = the_end_of_time());
 
-    /**********
-    * CREATE *
-    **********/
-
-    bool entity_exists(
-            EntityId entity_id);
-
 protected:
 
     //! Create a new \c ListItem of class \c Host related with the backend entity with id \c id

--- a/include/fastdds_monitor/model/tree/StatusTreeModel.h
+++ b/include/fastdds_monitor/model/tree/StatusTreeModel.h
@@ -195,6 +195,12 @@ private:
     StatusTreeItem* internalPointer(
             const QModelIndex& index) const;
 
+    QModelIndex index_for_item(
+            StatusTreeItem* item) const;
+
+    bool belongs_to_model(
+            const StatusTreeItem* item) const;
+
     StatusTreeItem* filtered_copy(
             StatusTreeItem* source,
             const backend::EntityId entity_id);

--- a/qml/StatusTreeView.qml
+++ b/qml/StatusTreeView.qml
@@ -105,12 +105,18 @@ Flickable {
         root.clean_filter()
     }
 
+    function refreshTreeRoot() {
+        tree.childCount = root.model ? root.model.rowCount(tree.parentIndex) : 0
+    }
+
     Connections
     {
         target: root.model
-        function onLayoutChanged() {
-            root.filter_model_by_id(root.current_filter_)
-        }
+        ignoreUnknownSignals: true
+        function onLayoutChanged() { root.refreshTreeRoot() }
+        function onModelReset() { root.refreshTreeRoot() }
+        function onRowsInserted() { root.refreshTreeRoot() }
+        function onRowsRemoved() { root.refreshTreeRoot() }
     }
 
     Connections {
@@ -139,9 +145,10 @@ Flickable {
         Connections {
             target: root.model
             ignoreUnknownSignals: true
-            function onLayoutChanged() {
-               tree.childCount = root.model ? root.model.rowCount(tree.parentIndex) : 0
-            }
+            function onLayoutChanged() { root.refreshTreeRoot() }
+            function onModelReset() { root.refreshTreeRoot() }
+            function onRowsInserted() { root.refreshTreeRoot() }
+            function onRowsRemoved() { root.refreshTreeRoot() }
         }
     }
 

--- a/qml/StatusTreeViewItem.qml
+++ b/qml/StatusTreeViewItem.qml
@@ -240,21 +240,29 @@ Item {
                         controller.endpoint_click(_prop.currentId)
                         controller.participant_click(_prop.currentId)
                     }
+
+                    function refresh(){
+                        currentIndex = root.model.index(index, 0, parentIndex)
+                        currentData = root.model.data(currentIndex)
+                        currentId = root.model.id(currentIndex)
+                        currentStatus = root.model.status(currentIndex)
+                        currentKind = root.model.kind(currentIndex)
+                        currentValue = root.model.value(currentIndex)
+                        currentDescription = root.model.description(currentIndex)
+                        currentAlive = root.model.alive(currentIndex)
+                        itemChildCount = root.model.rowCount(currentIndex)
+                    }
                 }
 
                 Connections {
                     target: root.model
                     ignoreUnknownSignals: true
                     function onLayoutChanged() {
-                        const parent = root.model.index(index, 0, parentIndex)
-                        _prop.itemChildCount = root.model.rowCount(parent)
-                        // refresh counter
-                        var new_value = root.model.value(_prop.currentIndex)
-                        if (new_value != undefined)
-                        {
-                            _prop.currentValue = new_value
-                        }
+                        _prop.refresh()
                     }
+                    function onModelReset() { _prop.refresh() }
+                    function onRowsInserted() { _prop.refresh() }
+                    function onRowsRemoved() { _prop.refresh() }
                 }
 
                 Connections {
@@ -380,6 +388,18 @@ Item {
                         target: root.model
                         ignoreUnknownSignals: true
                         function onLayoutChanged() {
+                            const parent = root.model.index(index, 0, parentIndex)
+                            loader.item.childCount = root.model.rowCount(parent)
+                        }
+                        function onModelReset() {
+                            const parent = root.model.index(index, 0, parentIndex)
+                            loader.item.childCount = root.model.rowCount(parent)
+                        }
+                        function onRowsInserted() {
+                            const parent = root.model.index(index, 0, parentIndex)
+                            loader.item.childCount = root.model.rowCount(parent)
+                        }
+                        function onRowsRemoved() {
                             const parent = root.model.index(index, 0, parentIndex)
                             loader.item.childCount = root.model.rowCount(parent)
                         }

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -33,6 +33,7 @@
 #include <QStringListModel>
 #include <QtCore/QRandomGenerator>
 
+#include <fastdds_monitor/backend/backend_utils.h>
 #include <fastdds_monitor/backend/backend_types.h>
 #include <fastdds_monitor/backend/Listener.h>
 #include <fastdds_monitor/backend/SyncBackendConnection.h>
@@ -54,6 +55,64 @@
 
 using EntityInfo = backend::EntityInfo;
 using UserDataInfo = backend::UserDataInfo;
+
+static std::string callback_entity_label(
+        const backend::EntityId& id,
+        backend::EntityKind kind = backend::EntityKind::INVALID)
+{
+    std::ostringstream ss;
+    if (kind != backend::EntityKind::INVALID)
+    {
+        ss << utils::to_string(backend::entity_kind_to_QString(kind)) << " ";
+    }
+    else
+    {
+        ss << "Entity ";
+    }
+
+    ss << id.value();
+    return ss.str();
+}
+
+static bool missing_info_value(
+        const std::string& value)
+{
+    return value.empty() || value.rfind("No key ", 0) == 0;
+}
+
+static std::string unique_time_key(
+        const EntityInfo& entries,
+        const std::string& base_time)
+{
+    if (!entries.contains(base_time))
+    {
+        return base_time;
+    }
+
+    QDateTime time = QDateTime::fromString(QString::fromStdString(base_time), "yyyy-MM-dd HH:mm:ss.zzz");
+    if (!time.isValid())
+    {
+        std::size_t suffix = 1;
+        std::string candidate;
+        do
+        {
+            candidate = base_time + " +" + std::to_string(suffix++);
+        }
+        while (entries.contains(candidate));
+
+        return candidate;
+    }
+
+    std::string candidate = base_time;
+    do
+    {
+        time = time.addMSecs(1);
+        candidate = time.toString("yyyy-MM-dd HH:mm:ss.zzz").toStdString();
+    }
+    while (entries.contains(candidate));
+
+    return candidate;
+}
 
 Engine::Engine()
     : enabled_(false)
@@ -189,19 +248,22 @@ QObject* Engine::enable()
         this,
         &Engine::new_callback_signal,
         this,
-        &Engine::new_callback_slot);
+        &Engine::new_callback_slot,
+        Qt::QueuedConnection);
 
     QObject::connect(
         this,
         &Engine::new_status_callback_signal,
         this,
-        &Engine::new_status_callback_slot);
+        &Engine::new_status_callback_slot,
+        Qt::QueuedConnection);
 
     QObject::connect(
         this,
         &Engine::new_alert_callback_signal,
         this,
-        &Engine::new_alert_callback_slot);
+        &Engine::new_alert_callback_slot,
+        Qt::QueuedConnection);
 
     // Set enable as True
     enabled_ = true;
@@ -721,7 +783,8 @@ bool Engine::add_log_callback_(
         std::string callback,
         std::string time)
 {
-    log_info_["Callbacks"][time] = callback;
+    EntityInfo& callbacks = log_info_["Callbacks"];
+    callbacks[unique_time_key(callbacks, time)] = callback;
     fill_log_();
 
     return true;
@@ -1188,7 +1251,7 @@ void Engine::refresh_engine(
     {
         // Check that physical/logical entity still exist
         if (old_entities_clicked.is_physical_logical_clicked() &&
-                backend_connection_.entity_exists(old_entities_clicked.physical_logical.id))
+                !backend_connection_.get_info(old_entities_clicked.physical_logical.id).empty())
         {
             qDebug() << "Keep old clicked in refresh and setting old entity";
 
@@ -1207,7 +1270,7 @@ void Engine::refresh_engine(
 
         // Check that dds entity still exist
         if (old_entities_clicked.is_dds_clicked() &&
-                backend_connection_.entity_exists(old_entities_clicked.dds.id))
+                !backend_connection_.get_info(old_entities_clicked.dds.id).empty())
         {
             qDebug() << "Keep old clicked in refresh and setting old DDS entity";
 
@@ -1406,13 +1469,13 @@ bool Engine::read_callback_(
     if (callback.is_update)
     {
         // Add callback of updating entity to log model
-        add_log_callback_("Update info in entity " + backend_connection_.get_name(callback.entity_id),
+        add_log_callback_("Update info in " + callback_entity_label(callback.entity_id, callback.entity_kind),
                 utils::now());
     }
     else
     {
         // Add callback to log model
-        add_log_callback_("New entity " + backend_connection_.get_name(callback.entity_id) + " discovered",
+        add_log_callback_("New " + callback_entity_label(callback.entity_id, callback.entity_kind) + " discovered",
                 utils::now());
 
         // Add one to the number of discovered entities
@@ -1430,7 +1493,7 @@ bool Engine::read_callback_(
     std::lock_guard<std::recursive_mutex> lock(initializing_monitor_);
 
     // Add callback to log model
-    add_log_callback_("New entity (" + backend_connection_.get_name(status_callback.entity_id) + ") status reported: "
+    add_log_callback_("Status reported for " + callback_entity_label(status_callback.entity_id) + ": "
             + backend::status_kind_to_string(status_callback.status_kind),
             utils::now());
 
@@ -1494,8 +1557,26 @@ bool Engine::update_entity_status(
     {
         backend::StatusLevel new_status = backend::StatusLevel::OK_STATUS;
         std::string description = backend::entity_status_description(kind);
-        std::string entity_guid = backend_connection_.get_guid(id);
-        std::string entity_kind = utils::to_string(backend::entity_kind_to_QString(backend_connection_.get_type(id)));
+        EntityInfo entity_info = backend_connection_.get_info(id);
+        if (entity_info.empty())
+        {
+            return false;
+        }
+
+        const std::string entity_guid = backend::get_info_value(entity_info, "guid");
+        const std::string entity_name = backend::get_info_value(entity_info, "name");
+        const std::string entity_kind = backend::get_info_value(entity_info, "kind");
+        const std::string entity_label =
+                (!missing_info_value(entity_kind) && !missing_info_value(entity_name)) ?
+                entity_kind + ": " + entity_name :
+                callback_entity_label(id);
+
+        auto get_entity_item =
+                [&](backend::StatusLevel status)
+                {
+                    return entity_status_model_->getTopLevelItem(id, entity_label, status, description, entity_guid);
+                };
+
         switch (kind)
         {
             case backend::StatusKind::DEADLINE_MISSED:
@@ -1505,10 +1586,7 @@ bool Engine::update_entity_status(
                 {
                     if (sample.status != backend::StatusLevel::OK_STATUS)
                     {
-                        backend::StatusLevel entity_status = backend_connection_.get_status(id);
-                        auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(
-                                id), entity_status, description, entity_guid);
+                        auto entity_item = get_entity_item(sample.status);
                         new_status = sample.status;
                         std::string handle_string;
                         auto deadline_missed_item = new models::StatusTreeItem(id, kind, std::string("Deadline missed"),
@@ -1538,10 +1616,7 @@ bool Engine::update_entity_status(
                 {
                     if (sample.status != backend::StatusLevel::OK_STATUS)
                     {
-                        backend::StatusLevel entity_status = backend_connection_.get_status(id);
-                        auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(
-                                id), entity_status, description, entity_guid);
+                        auto entity_item = get_entity_item(sample.status);
                         new_status = sample.status;
                         auto inconsistent_topic_item =
                                 new models::StatusTreeItem(id, kind, std::string("Inconsistent topics:"),
@@ -1560,10 +1635,7 @@ bool Engine::update_entity_status(
                 {
                     if (sample.status != backend::StatusLevel::OK_STATUS)
                     {
-                        backend::StatusLevel entity_status = backend_connection_.get_status(id);
-                        auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(
-                                id), entity_status, description, entity_guid);
+                        auto entity_item = get_entity_item(sample.status);
                         new_status = sample.status;
                         auto liveliness_changed_item =
                                 new models::StatusTreeItem(id, kind, std::string("Liveliness changed"),
@@ -1600,10 +1672,7 @@ bool Engine::update_entity_status(
                 {
                     if (sample.status != backend::StatusLevel::OK_STATUS)
                     {
-                        backend::StatusLevel entity_status = backend_connection_.get_status(id);
-                        auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(
-                                id), entity_status, description, entity_guid);
+                        auto entity_item = get_entity_item(sample.status);
                         new_status = sample.status;
                         auto liveliness_lost_item = new models::StatusTreeItem(id, kind, std::string(
                                             "Liveliness lost:"),
@@ -1622,10 +1691,7 @@ bool Engine::update_entity_status(
                 {
                     if (sample.status != backend::StatusLevel::OK_STATUS)
                     {
-                        backend::StatusLevel entity_status = backend_connection_.get_status(id);
-                        auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(
-                                id), entity_status, description, entity_guid);
+                        auto entity_item = get_entity_item(sample.status);
                         new_status = sample.status;
                         auto samples_lost_item = new models::StatusTreeItem(id, kind, std::string("Samples lost:"),
                                         sample.status, std::to_string(
@@ -1649,10 +1715,7 @@ bool Engine::update_entity_status(
                         {
                             fastdds_version = fastdds_version.substr(0, fastdds_version.find_last_of('.'));
                         }
-                        backend::StatusLevel entity_status = backend_connection_.get_status(id);
-                        auto entity_item = entity_status_model_->getTopLevelItem(
-                            id, entity_kind + ": " + backend_connection_.get_name(
-                                id), entity_status, description, entity_guid);
+                        auto entity_item = get_entity_item(sample.status);
                         new_status = sample.status;
 
                         auto incompatible_qos_item = new models::StatusTreeItem(id, kind, std::string(
@@ -1686,13 +1749,24 @@ bool Engine::update_entity_status(
                                     remote_entity_guid);
                                 if (remote_entity_id.is_valid())
                                 {
-                                    EntityInfo entity_info = backend_connection_.get_info(remote_entity_id);
-                                    std::string remote_entity_kind = utils::to_string(
-                                        backend::entity_kind_to_QString(backend_connection_.get_type(
-                                            remote_entity_id)));
-                                    std::stringstream ss;
-                                    ss << std::string(entity_info["alias"]) << " (" << remote_entity_kind << ")";
-                                    remote_entity = ss.str();
+                                    EntityInfo remote_entity_info = backend_connection_.get_info(remote_entity_id);
+                                    const std::string remote_entity_alias =
+                                            backend::get_info_value(remote_entity_info, "alias");
+                                    const std::string remote_entity_kind =
+                                            backend::get_info_value(remote_entity_info, "kind");
+
+                                    if (!remote_entity_info.empty() &&
+                                            !missing_info_value(remote_entity_alias) &&
+                                            !missing_info_value(remote_entity_kind))
+                                    {
+                                        std::stringstream ss;
+                                        ss << remote_entity_alias << " (" << remote_entity_kind << ")";
+                                        remote_entity = ss.str();
+                                    }
+                                    else
+                                    {
+                                        remote_entity = callback_entity_label(remote_entity_id);
+                                    }
                                 }
                                 else
                                 {
@@ -1750,9 +1824,6 @@ bool Engine::update_entity_status(
                 controller_->status_counters.warnings[id] = counter;
                 controller_->status_counters.total_warnings += controller_->status_counters.warnings[id];
             }
-            // notify status model layout changed to refresh layout view
-            emit entity_status_proxy_model_->layoutAboutToBeChanged();
-
             emit controller_->update_status_counters(
                 QString::number(controller_->status_counters.total_errors),
                 QString::number(controller_->status_counters.total_warnings));
@@ -1765,9 +1836,6 @@ bool Engine::update_entity_status(
 
             // update view
             entity_status_proxy_model_->set_source_model(entity_status_model_);
-
-            // notify status model layout changed to refresh layout view
-            emit entity_status_proxy_model_->layoutChanged();
         }
     }
     return true;
@@ -1781,13 +1849,20 @@ bool Engine::remove_inactive_entities_from_status_model(
     {
         // get info from id
         EntityInfo entity_info = backend_connection_.get_info(id);
+        if (entity_info.empty() || !entity_info.contains("alive") || !entity_info["alive"].is_boolean())
+        {
+            return false;
+        }
+
+        const bool entity_alive = entity_info["alive"].get<bool>();
+        const std::string entity_guid = backend::get_info_value(entity_info, "guid");
 
         // update status model if not alive
-        if (!entity_info["alive"])
+        if (!entity_alive)
         {
             // remove item from tree
             entity_status_model_->removeItem(entity_status_model_->getTopLevelItem(id, "",
-                    backend::StatusLevel::OK_STATUS, "", entity_info["guid"]));
+                    backend::StatusLevel::OK_STATUS, "", entity_guid));
 
             // add empty item if removed last item
             if (entity_status_model_->rowCount(entity_status_model_->rootIndex()) == 0)
@@ -1810,11 +1885,11 @@ bool Engine::remove_inactive_entities_from_status_model(
             // Check if entity has associated errors in other entities
             for (auto& sh_error_map : controller_->status_counters.shared_errors)
             {
-                if (sh_error_map.second.find(entity_info["guid"]) != sh_error_map.second.end())
+                if (sh_error_map.second.find(entity_guid) != sh_error_map.second.end())
                 {
-                    controller_->status_counters.total_errors -= sh_error_map.second[entity_info["guid"]];
-                    controller_->status_counters.errors[sh_error_map.first] -= sh_error_map.second[entity_info["guid"]];
-                    sh_error_map.second.erase(entity_info["guid"]);
+                    controller_->status_counters.total_errors -= sh_error_map.second[entity_guid];
+                    controller_->status_counters.errors[sh_error_map.first] -= sh_error_map.second[entity_guid];
+                    sh_error_map.second.erase(entity_guid);
                 }
             }
 
@@ -1837,18 +1912,12 @@ bool Engine::remove_inactive_entities_from_status_model(
             }
             controller_->status_counters.warnings.erase(id);
 
-            // refresh layout
-            emit entity_status_proxy_model_->layoutAboutToBeChanged();
-
             emit controller_->update_status_counters(
                 QString::number(controller_->status_counters.total_errors),
                 QString::number(controller_->status_counters.total_warnings));
 
             // update view
             entity_status_proxy_model_->set_source_model(entity_status_model_);
-
-            // notify status model layout changed to refresh layout view
-            emit entity_status_proxy_model_->layoutChanged();
         }
         return true;
     }

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -923,7 +923,7 @@ std::string SyncBackendConnection::get_guid(
     return backend::get_info_value(get_info(id), "guid");
 }
 
-StatusLevel SyncBackendConnection:: get_status(
+StatusLevel SyncBackendConnection::get_status(
         EntityId id)
 {
     try
@@ -2013,52 +2013,52 @@ std::vector<std::string> SyncBackendConnection::ds_supported_transports()
 std::vector<std::string> SyncBackendConnection::get_statistic_kinds()
 {
     return std::vector<std::string>({
-            "MEAN",
-            "STANDARD_DEVIATION",
-            "MAX",
-            "MIN",
-            "MEDIAN",
+                       "MEAN",
+                       "STANDARD_DEVIATION",
+                       "MAX",
+                       "MIN",
+                       "MEDIAN",
 #if !defined(NDEBUG)
-            "COUNT",
+                       "COUNT",
 #endif // if !defined(NDEBUG)
-            "SUM",
-            "RAW DATA"
-        });
+                       "SUM",
+                       "RAW DATA"
+                   });
 }
 
 std::vector<std::string> SyncBackendConnection::get_data_kinds()
 {
     return std::vector<std::string>({
-            "FASTDDS_LATENCY",
-            "PUBLICATION_THROUGHPUT",
-            "SUBSCRIPTION_THROUGHPUT",
-            // The following data kinds are currently under development and are therefore only displayed if the monitor
-            // is compiled in Debug.
+                       "FASTDDS_LATENCY",
+                       "PUBLICATION_THROUGHPUT",
+                       "SUBSCRIPTION_THROUGHPUT",
+                       // The following data kinds are currently under development and are therefore only displayed if the monitor
+                       // is compiled in Debug.
 #if !defined(NDEBUG)
-            "NETWORK_LATENCY",
-            "RTPS_PACKETS_SENT",
-            "RTPS_BYTES_SENT",
-            "RTPS_PACKETS_LOST",
-            "RTPS_BYTES_LOST",
-            "DISCOVERY_TIME",
-            "SAMPLE_DATAS",
+                       "NETWORK_LATENCY",
+                       "RTPS_PACKETS_SENT",
+                       "RTPS_BYTES_SENT",
+                       "RTPS_PACKETS_LOST",
+                       "RTPS_BYTES_LOST",
+                       "DISCOVERY_TIME",
+                       "SAMPLE_DATAS",
 #endif // #if !defined(NDEBUG)
-            "RESENT_DATA",
-            "HEARTBEAT_COUNT",
-            "ACKNACK_COUNT",
-            "NACKFRAG_COUNT",
-            "GAP_COUNT",
-            "DATA_COUNT",
-            "PDP_PACKETS",
-            "EDP_PACKETS"
-        });
+                       "RESENT_DATA",
+                       "HEARTBEAT_COUNT",
+                       "ACKNACK_COUNT",
+                       "NACKFRAG_COUNT",
+                       "GAP_COUNT",
+                       "DATA_COUNT",
+                       "PDP_PACKETS",
+                       "EDP_PACKETS"
+                   });
 }
 
 std::vector<std::string> SyncBackendConnection::get_alert_kinds()
 {
     return std::vector<std::string>({
-            "NEW_DATA",
-            "NO_DATA"});
+                       "NEW_DATA",
+                       "NO_DATA"});
 }
 
 std::vector<std::pair<EntityKind, EntityKind>> SyncBackendConnection::get_data_supported_entity_kinds(

--- a/src/backend/SyncBackendConnection.cpp
+++ b/src/backend/SyncBackendConnection.cpp
@@ -637,6 +637,10 @@ EntityInfo SyncBackendConnection::get_info(
         // Refactor json info so there are no vectors
         return backend::refactor_json(StatisticsBackend::get_info(id));
     }
+    catch (const BadParameter& )
+    {
+        return EntityInfo();
+    }
     catch (const Exception& e)
     {
         qWarning() << "Fail getting entity info: " << e.what();
@@ -649,9 +653,18 @@ EntityInfo SyncBackendConnection::get_info(
 AlertSummary SyncBackendConnection::get_info(
         AlertId id)
 {
+    if (id == AlertId())
+    {
+        return EntityInfo();
+    }
+
     try
     {
         return backend::refactor_json(StatisticsBackend::get_info(id));
+    }
+    catch (const BadParameter& )
+    {
+        return EntityInfo();
     }
     catch (const Exception& e)
     {
@@ -665,13 +678,31 @@ AlertSummary SyncBackendConnection::get_info(
 backend::EntityId SyncBackendConnection::get_endpoint_topic_id(
         backend::EntityId endpoint_id)
 {
-    return StatisticsBackend::get_endpoint_topic_id(endpoint_id);
+    try
+    {
+        return StatisticsBackend::get_endpoint_topic_id(endpoint_id);
+    }
+    catch (const Exception& e)
+    {
+        qWarning() << "Fail getting endpoint topic id: " << e.what();
+        static_cast<void>(e);
+        return EntityId::invalid();
+    }
 }
 
 backend::EntityId SyncBackendConnection::get_domain_id(
         backend::EntityId entity_id)
 {
-    return StatisticsBackend::get_domain_id(entity_id);
+    try
+    {
+        return StatisticsBackend::get_domain_id(entity_id);
+    }
+    catch (const Exception& e)
+    {
+        qWarning() << "Fail getting domain id: " << e.what();
+        static_cast<void>(e);
+        return EntityId::invalid();
+    }
 }
 
 bool SyncBackendConnection::get_alive(
@@ -680,6 +711,10 @@ bool SyncBackendConnection::get_alive(
     try
     {
         return StatisticsBackend::is_active(id);
+    }
+    catch (const BadParameter& )
+    {
+        return false;
     }
     catch (const Exception& e)
     {
@@ -697,6 +732,10 @@ bool SyncBackendConnection::is_metatraffic(
     {
         return StatisticsBackend::is_metatraffic(id);
     }
+    catch (const BadParameter& )
+    {
+        return false;
+    }
     catch (const Exception& e)
     {
         qWarning() << "Fail getting entity metatraffic attribute: " << e.what();
@@ -712,6 +751,10 @@ bool SyncBackendConnection::is_proxy(
     try
     {
         return StatisticsBackend::is_proxy(id);
+    }
+    catch (const BadParameter& )
+    {
+        return false;
     }
     catch (const Exception& e)
     {
@@ -729,6 +772,10 @@ EntityKind SyncBackendConnection::get_type(
     {
         return StatisticsBackend::get_type(id);
     }
+    catch (const BadParameter& )
+    {
+        return EntityKind::INVALID;
+    }
     catch (const Exception& e)
     {
         qWarning() << "Fail getting entity type: " << e.what();
@@ -741,9 +788,18 @@ EntityKind SyncBackendConnection::get_type(
 backend::EntityId SyncBackendConnection::get_entity_by_guid(
         const std::string& guid)
 {
+    if (guid.empty())
+    {
+        return EntityId::invalid();
+    }
+
     try
     {
         return StatisticsBackend::get_entity_by_guid(guid);
+    }
+    catch (const BadParameter& )
+    {
+        return EntityId::invalid();
     }
     catch (const Exception& e)
     {
@@ -761,6 +817,10 @@ std::vector<EntityId> SyncBackendConnection::get_entities(
     try
     {
         return StatisticsBackend::get_entities(entity_type, entity_id);
+    }
+    catch (const BadParameter& )
+    {
+        return std::vector<EntityId>();
     }
     catch (const Exception& e)
     {
@@ -866,7 +926,20 @@ std::string SyncBackendConnection::get_guid(
 StatusLevel SyncBackendConnection:: get_status(
         EntityId id)
 {
-    return StatisticsBackend::get_status(id);
+    try
+    {
+        return StatisticsBackend::get_status(id);
+    }
+    catch (const BadParameter& )
+    {
+        return StatusLevel::OK_STATUS;
+    }
+    catch (const Exception& e)
+    {
+        qWarning() << "Fail getting entity status: " << e.what();
+        static_cast<void>(e);
+        return StatusLevel::OK_STATUS;
+    }
 }
 
 std::vector<StatisticsData> SyncBackendConnection::get_data(
@@ -947,12 +1020,6 @@ void SyncBackendConnection::clear_statistics_data(
         Timestamp time_to /* = the_end_of_time() */)
 {
     return StatisticsBackend::clear_statistics_data(time_to);
-}
-
-bool SyncBackendConnection::entity_exists(
-        EntityId entity_id)
-{
-    return !get_info(entity_id).empty();
 }
 
 bool SyncBackendConnection::data_available(
@@ -1151,7 +1218,20 @@ bool SyncBackendConnection::get_status_data(
 std::string SyncBackendConnection::get_deserialized_guid(
         const backend::GUID_s& data)
 {
-    return StatisticsBackend::deserialize_guid(data);
+    try
+    {
+        return StatisticsBackend::deserialize_guid(data);
+    }
+    catch (const BadParameter&)
+    {
+        return std::string();
+    }
+    catch (const Exception& e)
+    {
+        qWarning() << "Fail deserializing GUID: " << e.what();
+        static_cast<void>(e);
+        return std::string();
+    }
 }
 
 backend::GUID_s SyncBackendConnection::get_serialize_guid(

--- a/src/model/tree/StatusTreeModel.cpp
+++ b/src/model/tree/StatusTreeModel.cpp
@@ -414,8 +414,8 @@ void StatusTreeModel::addItem(
             // parent_item_ is set but child is not in parent's list — inconsistent tree state.
             // Row-based view notifications are skipped because no valid row index exists.
             qWarning()
-                        <<
-                        "StatusTreeModel::addItem: child has parent pointer but row() == -1, tree state is inconsistent";
+                <<
+                "StatusTreeModel::addItem: child has parent pointer but row() == -1, tree state is inconsistent";
             previous_parent->child_items_.removeAll(child);
         }
         child->setParentItem(nullptr);

--- a/src/model/tree/StatusTreeModel.cpp
+++ b/src/model/tree/StatusTreeModel.cpp
@@ -42,6 +42,7 @@
 #include <fastdds_monitor/model/tree/StatusTreeModel.h>
 
 #include <iostream>
+#include <QDebug>
 #include <QQmlEngine>
 
 #include <fastdds_monitor/backend/backend_utils.h>
@@ -131,6 +132,11 @@ StatusTreeItem* StatusTreeModel::filtered_copy(
 int StatusTreeModel::rowCount(
         const QModelIndex& parent) const
 {
+    if (parent.column() > 0)
+    {
+        return 0;
+    }
+
     if (!parent.isValid())
     {
         return root_item_->childCount();
@@ -353,6 +359,9 @@ void StatusTreeModel::addItem(
     }
 
 
+    const bool parent_in_model = belongs_to_model(parent);
+    const QModelIndex parent_index = index_for_item(parent);
+
     // if parent is topLevelItem (entity item)
     if (parent->id() != backend::ID_ALL && parent->kind() == backend::StatusKind::INVALID)
     {
@@ -362,14 +371,19 @@ void StatusTreeModel::addItem(
             // if overriding status, remove previous status
             if (parent->child(i)->id() == child->id() && parent->child(i)->kind() == child->kind())
             {
-                emit layoutAboutToBeChanged();
                 // Prevent removing entity item if it is the only child
                 parent->set_delete_if_no_children(false);
-                beginRemoveRows(QModelIndex(), qMax(parent->childCount() - 1, 0), qMax(parent->childCount(), 0));
+                if (parent_in_model)
+                {
+                    beginRemoveRows(parent_index, i, i);
+                }
                 parent->removeChild(parent->child(i));
-                endRemoveRows();
+                if (parent_in_model)
+                {
+                    endRemoveRows();
+                }
                 parent->set_delete_if_no_children(true);
-                emit layoutChanged();
+                break;
             }
         }
     }
@@ -378,24 +392,51 @@ void StatusTreeModel::addItem(
         QObject::connect(this, &StatusTreeModel::itemRemoved, child, &StatusTreeItem::onItemRemoved);
     }
 
-    emit layoutAboutToBeChanged();
-
     // remove possible parent from new child
     if (child->parentItem())
     {
-        beginRemoveRows(QModelIndex(), qMax(parent->childCount() - 1, 0), qMax(parent->childCount(), 0));
-        child->parentItem()->removeChild(child);
-        endRemoveRows();
+        StatusTreeItem* previous_parent = child->parentItem();
+        const bool previous_parent_in_model = belongs_to_model(previous_parent);
+        const QModelIndex previous_parent_index = index_for_item(previous_parent);
+        const int previous_row = child->row();
+
+        if (previous_parent_in_model && previous_row >= 0)
+        {
+            beginRemoveRows(previous_parent_index, previous_row, previous_row);
+        }
+
+        if (previous_row >= 0)
+        {
+            previous_parent->child_items_.removeAt(previous_row);
+        }
+        else
+        {
+            // parent_item_ is set but child is not in parent's list — inconsistent tree state.
+            // Row-based view notifications are skipped because no valid row index exists.
+            qWarning() << "StatusTreeModel::addItem: child has parent pointer but row() == -1, tree state is inconsistent";
+            previous_parent->child_items_.removeAll(child);
+        }
+        child->setParentItem(nullptr);
+
+        if (previous_parent_in_model && previous_row >= 0)
+        {
+            endRemoveRows();
+        }
     }
 
-    beginInsertRows(QModelIndex(), qMax(parent->childCount() - 1, 0), qMax(parent->childCount() - 1, 0));
+    const int insert_row = parent->childCount();
+    if (parent_in_model)
+    {
+        beginInsertRows(parent_index, insert_row, insert_row);
+    }
     // set new parent in the child
     child->setParentItem(parent);
     // append child in parent's child list
     parent->appendChild(child);
-    endInsertRows();
-
-    emit layoutChanged();
+    if (parent_in_model)
+    {
+        endInsertRows();
+    }
 }
 
 void StatusTreeModel::removeItem(
@@ -406,16 +447,22 @@ void StatusTreeModel::removeItem(
         return;
     }
 
-    emit layoutAboutToBeChanged();
-
     if (item->parentItem())
     {
-        beginRemoveRows(QModelIndex(), qMax(item->childCount() - 1, 0), qMax(item->childCount(), 0));
-        item->parentItem()->removeChild(item);
-        endRemoveRows();
-    }
+        const QModelIndex parent_index = index_for_item(item->parentItem());
+        const int row = item->row();
+        const bool item_in_model = belongs_to_model(item);
 
-    emit layoutChanged();
+        if (item_in_model && row >= 0)
+        {
+            beginRemoveRows(parent_index, row, row);
+        }
+        item->parentItem()->removeChild(item);
+        if (item_in_model && row >= 0)
+        {
+            endRemoveRows();
+        }
+    }
 }
 
 StatusTreeItem* StatusTreeModel::rootItem() const
@@ -448,7 +495,6 @@ int StatusTreeModel::depth(
 
 void StatusTreeModel::clear()
 {
-    emit layoutAboutToBeChanged();
     beginResetModel();
     // NOTE: When the root item is deleted, all its children are also deleted. This causes every leaf node to receive a signal notifying the destruction
     // of every entity item, which is unnecessary. Disconnecting all signal-slot communications between the TreeModel and leaf nodes (i.e., disconnecting
@@ -456,14 +502,43 @@ void StatusTreeModel::clear()
     disconnect_all_item_signals();
     delete root_item_;
     root_item_ = new StatusTreeItem();
+    is_empty_ = false;
     endResetModel();
-    emit layoutChanged();
 }
 
 StatusTreeItem* StatusTreeModel::internalPointer(
         const QModelIndex& index) const
 {
     return static_cast<StatusTreeItem*>(index.internalPointer());
+}
+
+QModelIndex StatusTreeModel::index_for_item(
+        StatusTreeItem* item) const
+{
+    if (!item || item == root_item_ || !belongs_to_model(item))
+    {
+        return {};
+    }
+
+    const int row = item->row();
+    if (row < 0)
+    {
+        return {};
+    }
+
+    return createIndex(row, 0, item);
+}
+
+bool StatusTreeModel::belongs_to_model(
+        const StatusTreeItem* item) const
+{
+    const StatusTreeItem* current = item;
+    while (current && current->parent_item_)
+    {
+        current = current->parent_item_;
+    }
+
+    return current == root_item_;
 }
 
 bool StatusTreeModel::containsTopLevelItem(
@@ -513,17 +588,15 @@ bool StatusTreeModel::is_empty()
 
 void StatusTreeModel::removeEmptyItem()
 {
-    emit layoutAboutToBeChanged();
     for (int i = 0; i < root_item_->childCount(); i++)
     {
         if (root_item_->child(i)->id() == backend::ID_ALL)
         {
-            root_item_->removeChild(root_item_->child(i));
+            removeItem(root_item_->child(i));
             is_empty_ = false;
             break;
         }
     }
-    emit layoutChanged();
 }
 
 StatusTreeItem*  StatusTreeModel::getTopLevelItem(

--- a/src/model/tree/StatusTreeModel.cpp
+++ b/src/model/tree/StatusTreeModel.cpp
@@ -413,7 +413,9 @@ void StatusTreeModel::addItem(
         {
             // parent_item_ is set but child is not in parent's list — inconsistent tree state.
             // Row-based view notifications are skipped because no valid row index exists.
-            qWarning() << "StatusTreeModel::addItem: child has parent pointer but row() == -1, tree state is inconsistent";
+            qWarning()
+                        <<
+                        "StatusTreeModel::addItem: child has parent pointer but row() == -1, tree state is inconsistent";
             previous_parent->child_items_.removeAll(child);
         }
         child->setParentItem(nullptr);


### PR DESCRIPTION
## Description

Adding a publisher or subscriber with a strict QoS policy (e.g. Deadline 50 ms) causes the monitor to crash in Windows as soon as the first status warning appears in the participant panel.

**Crash path:**

1. Backend fires a `DEADLINE_MISSED` (or any other status) callback
2. `read_callback_()` builds a log entry by calling `backend_connection_.get_name(entity_id)` — no exception guard
3. `update_entity_status()` calls `get_guid(id)`, `get_type(id)`, then `get_status(id)` — `get_status()` had **no try/catch at all**
4. If the entity's state changed between the callback arriving and the call executing (rapid connect/disconnect, proxy participant, etc.), the backend throws `BadParameter` or `Exception`
5. Exception propagates through all layers → unhandled → app terminates

The same unguarded pattern existed across `get_endpoint_topic_id()`,
`get_domain_id()`, and every `is_*` / `get_alive()` call, making any
rapid entity churn a potential crash.

---

## Changes

- `SyncBackendConnection`: guard all backend calls
- `Engine`: eliminate backend calls on the callback thread
- `StatusTreeModel`: fix Qt model protocol violations

### -- Basic extra changes -- 

- `Engine`: 
  - unique_time_key(...) to avoid log entry overwrites when callbacks share the same timestamp
  - Qt::QueuedConnection for callback/status/alert signal delivery
- `SyncBackendConnection.cpp`:
  - extra guard for get_deserialized_guid(...)


- `StatusTreeView.qml` & `StatusTreeViewItem.qml`

Original status-tree model refactor removed old layoutChanged behavior, and the Problems pane needed to be updated to react to modelReset / row insert / row remove signals.


---

<img width="482" height="391" alt="image" src="https://github.com/user-attachments/assets/f01d6368-c1ee-4fe0-87ce-15255e408f14" />
